### PR TITLE
fix: error with intercept routes

### DIFF
--- a/src/cli/utils/findRule.js
+++ b/src/cli/utils/findRule.js
@@ -1,12 +1,31 @@
 // Pure utility to find a matching rule
 // Usage: findRule(method, url, rules)
 
+
+/**
+ * @typedef {Object} Rule
+ * @property {string} method - HTTP method (e.g., 'GET', 'POST')
+ * @property {string} url - URL string or regex pattern
+ * @property {boolean} [urlRegex] - Whether the url is a regex pattern
+ * @property {string} alias - Alias for the rule
+ */
+
+/**
+ * Find a matching rule based on method and url
+ * @param {string} method
+ * @param {string} url
+ * @param {Array<Rule>} rules
+ * @returns {Rule|undefined}
+ */
 export function findRule(method, url, rules) {
   return rules.find(
     (r) => {
       const isMethodMatch = r.method.toLowerCase() === method.toLowerCase();
-      const isUrlMatch = typeof url === 'string'
-        ? r.url === url || r.url.includes(url) : new RegExp(url).test(r.url);
+      if (r.urlRegex) {
+        const regex = new RegExp(r.url);
+        return isMethodMatch && regex.test(url);
+      }
+      const isUrlMatch = r.url === url || url.includes(r.url);
       return isMethodMatch && isUrlMatch;
   });
 }

--- a/src/commands/mockBridge.ts
+++ b/src/commands/mockBridge.ts
@@ -8,6 +8,7 @@ export type Rule = {
   request?: unknown;
   status?: number;
   headers?: Record<string, string>;
+  urlRegex?: boolean;
 };
 
 export interface Options {
@@ -16,6 +17,7 @@ export interface Options {
   response: unknown;
   status?: number;
   headers?: Record<string, string>;
+  urlRegex?: boolean;
 }
 
 const rules: Rule[] = [];

--- a/src/tests/commands/mockBridge/mockRequest.spec.ts
+++ b/src/tests/commands/mockBridge/mockRequest.spec.ts
@@ -43,6 +43,7 @@ describe('mockBridge mock request methods', () => {
       method: 'GET',
       response: mockResponse,
       headers: { 'Content-Type': 'application/json' },
+      urlRegex: true,
     });
 
     expect(postMessageMock).toHaveBeenNthCalledWith(1, {
@@ -55,6 +56,7 @@ describe('mockBridge mock request methods', () => {
         response: mockResponse,
         headers: { 'Content-Type': 'application/json' },
         executed: false,
+        urlRegex: false,
       }),
     });
 


### PR DESCRIPTION
This pull request enhances the rule-matching utility for HTTP mocks by adding explicit support for URL regex matching. It introduces a `urlRegex` property to the `Rule` type, updates the matching logic in `findRule` to use regular expressions when specified, and expands test coverage to ensure correct behavior for both string and regex URL rules.

**Rule matching improvements:**

* Added a `urlRegex` property to the `Rule` type and related interfaces, allowing each rule to specify whether its `url` should be interpreted as a regex pattern (`src/commands/mockBridge.ts`). [[1]](diffhunk://#diff-67890b5966c035c4caddf03759d6ea08ec6634b455cefaddaadd72ac3e9f3adaR11) [[2]](diffhunk://#diff-67890b5966c035c4caddf03759d6ea08ec6634b455cefaddaadd72ac3e9f3adaR20)
* Updated the `findRule` utility to check the `urlRegex` property and perform regex-based matching when enabled, otherwise falling back to string or substring matching (`src/cli/utils/findRule.js`).

**Testing enhancements:**

* Revised and expanded test cases for `findRule` to cover path-based, regex, and substring URL matching, as well as to clarify expected behaviors and edge cases (`src/tests/cli/findRule.spec.js`). [[1]](diffhunk://#diff-caf293172398e889884b784a7766faf988cc16cb5a3f6e32f69d12b076094f58L15-R46) [[2]](diffhunk://#diff-caf293172398e889884b784a7766faf988cc16cb5a3f6e32f69d12b076094f58R57-R64)
* Updated mock bridge request tests to include the `urlRegex` property, ensuring the new matching logic is exercised in integration scenarios (`src/tests/commands/mockBridge/mockRequest.spec.ts`). [[1]](diffhunk://#diff-ed59bbe958de31f3fe6729ece9a205d4e7b2900c5174eae50558cb7dff6448a4R46) [[2]](diffhunk://#diff-ed59bbe958de31f3fe6729ece9a205d4e7b2900c5174eae50558cb7dff6448a4R59)

This PR closes #25 
