### PR TITLE
feat: improve visit command

### DIFF
--- a/src/commands/mockBridge.ts
+++ b/src/commands/mockBridge.ts
@@ -1,3 +1,5 @@
+import { wait } from "../utils/wait";
+
 // mockBridge.ts
 export type Rule = {
   method: string;
@@ -43,8 +45,6 @@ export const initRequestMocking = async () => {
   }
 };
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 /**
  * Mock a network request.
  *
@@ -78,7 +78,7 @@ export const mockRequest = async (alias: string, options: Options) => {
     type: "ADD_RULE",
     rule,
   });
-  await sleep(SW_DELAY);
+  await wait(SW_DELAY);
   await Promise.resolve();
 };
 
@@ -88,7 +88,7 @@ export const mockRequest = async (alias: string, options: Options) => {
  * @returns The matched rule (with body if applicable)
  */
 export const waitForRequest = async (alias: string): Promise<Rule> => {
-  await sleep(SW_DELAY);
+  await wait(SW_DELAY);
   const rule = rules.find((r) => r.alias === alias && r.executed);
   if (rule) return Promise.resolve(rule);
   throw new Error("Rule not found or not executed");

--- a/src/commands/visit.ts
+++ b/src/commands/visit.ts
@@ -1,0 +1,11 @@
+import { wait } from "../utils/wait";
+import { log } from "../utils/log";
+
+const DELAY = 100;
+
+export const visit = async (url: string) => {
+  log(`visit("${url}")`);
+  window.history.pushState({}, "", url);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+  await wait(DELAY);
+};

--- a/src/twd.ts
+++ b/src/twd.ts
@@ -5,6 +5,7 @@ import { log } from "./utils/log";
 import { mockRequest, Options, Rule, waitForRequest, initRequestMocking, clearRequestMockRules, getRequestMockRules } from "./commands/mockBridge";
 import type { AnyAssertion, ArgsFor, TWDElemAPI } from "./twd-types";
 import urlCommand, { type URLCommandAPI } from "./commands/url";
+import { visit } from "./commands/visit";
 
 /**
  * Stores the function to run before each test.
@@ -198,11 +199,7 @@ export const twd: TWDAPI = {
     };
     return api;
   },
-  visit: (url: string) => {
-    log(`visit("${url}")`);
-    window.history.pushState({}, "", url);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  },
+  visit,
   url: urlCommand,
   mockRequest,
   waitForRequest,


### PR DESCRIPTION
This pull request refactors the way delays are handled in network request mocking and the `visit` command. The main improvement is the replacement of a locally defined `sleep` function with a shared `wait` utility, and the extraction of the `visit` logic into its own module for better code reuse and clarity.

**Refactoring and Code Reuse:**

* Replaced the locally defined `sleep` function in `mockBridge.ts` with the shared `wait` utility for consistent delay handling across the codebase. (`src/commands/mockBridge.ts`) [[1]](diffhunk://#diff-67890b5966c035c4caddf03759d6ea08ec6634b455cefaddaadd72ac3e9f3adaR1-R2) [[2]](diffhunk://#diff-67890b5966c035c4caddf03759d6ea08ec6634b455cefaddaadd72ac3e9f3adaL46-L47) [[3]](diffhunk://#diff-67890b5966c035c4caddf03759d6ea08ec6634b455cefaddaadd72ac3e9f3adaL81-R81) [[4]](diffhunk://#diff-67890b5966c035c4caddf03759d6ea08ec6634b455cefaddaadd72ac3e9f3adaL91-R91)
* Extracted the `visit` logic into a new `visit` command module, which now includes a delay using the shared `wait` utility and improved logging. (`src/commands/visit.ts`, `src/twd.ts`) [[1]](diffhunk://#diff-6cf60f1463bef43caac1f3e3df5820ab2647099eba928d15619f146287c9fedcR1-R11) [[2]](diffhunk://#diff-58669bcf1af1a19badc1a011167c2d427124a90220c0349fe48d9ead5d17aab0R8) [[3]](diffhunk://#diff-58669bcf1af1a19badc1a011167c2d427124a90220c0349fe48d9ead5d17aab0L201-R202)

This closes #30 