### PR TITLE
fix: remove truncate chai expects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 export * from './twd';
 export { TWDSidebar } from './ui/TWDSidebar';
+import { config } from 'chai';
 export { expect } from 'chai';
 export { userEvent } from './proxies/userEvent';
+
+config.truncateThreshold = 0;


### PR DESCRIPTION
This pull request makes a minor configuration change to the Chai assertion library to improve test output readability.

- Testing configuration:
  * Sets `config.truncateThreshold = 0` in `src/index.ts` to prevent Chai from truncating assertion output, ensuring full error messages are displayed during testing.

This PR closes #33 