### PR TITLE
fix: improve wait command

### DIFF
--- a/src/commands/mockBridge.ts
+++ b/src/commands/mockBridge.ts
@@ -91,7 +91,7 @@ export const waitForRequest = async (alias: string): Promise<Rule> => {
   await wait(SW_DELAY);
   const rule = rules.find((r) => r.alias === alias && r.executed);
   if (rule) return Promise.resolve(rule);
-  throw new Error("Rule not found or not executed");
+  throw new Error(`Rule ${alias} not found or not executed`);
 };
 
 /**

--- a/src/tests/commands/mockBridge/waitFor.spec.ts
+++ b/src/tests/commands/mockBridge/waitFor.spec.ts
@@ -57,6 +57,6 @@ describe('waitForRequest', () => {
 
   it('throws if the rule is not found or not executed', async () => {
     const alias = 'nonExistentAlias';
-    await expect(waitForRequest(alias)).rejects.toThrow('Rule not found or not executed');
+    await expect(waitForRequest(alias)).rejects.toThrow(`Rule ${alias} not found or not executed`);
   });
 });


### PR DESCRIPTION
This pull request makes a minor improvement to error reporting in the `waitForRequest` function and updates the related test to match the new error message format.

- **Error Message Improvement:**
  - The error thrown by `waitForRequest` now includes the `alias` in the message for better debugging context.

- **Test Update:**
  - The test for `waitForRequest` was updated to expect the new, more descriptive error message.

This closes #29 