### PR TITLE
feat: add get all methods

### DIFF
--- a/src/tests/e2e/api/getAll.spec.ts
+++ b/src/tests/e2e/api/getAll.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { twd } from '../../..';
+
+describe('twd getAll command', () => {
+  let item1: HTMLDivElement;
+  let item2: HTMLDivElement;
+  let item3: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    item1 = document.createElement('div');
+    item1.className = 'item';
+    item1.textContent = 'Hello';
+    document.body.appendChild(item1);
+
+    item2 = document.createElement('div');
+    item2.className = 'item';
+    item2.textContent = 'World';
+    document.body.appendChild(item2);
+
+    item3 = document.createElement('div');
+    item3.className = 'item';
+    item3.textContent = '!';
+    document.body.appendChild(item3);
+  });
+  
+  it('should get all elements', async () => {
+    const items = await twd.getAll('.item');
+    expect(items).toHaveLength(3);
+    expect(items[0].el).toBe(item1);
+    expect(items[1].el).toBe(item2);
+    expect(items[2].el).toBe(item3);
+  });
+
+  it('should return empty array if no elements found', async () => {
+    await expect(twd.getAll('.non-existent')).rejects.toThrow();
+  });
+});

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -13,4 +13,19 @@ export const waitForElement = (fn: () => HTMLElement | null, timeout = 2000, int
   });
 };
 
+export const waitForElements = (fn: () => NodeListOf<Element> | null, timeout = 2000, interval = 50) => {
+  return new Promise<Element[]>((resolve, reject) => {
+    const start = Date.now();
+
+    const check = () => {
+      const els = fn();
+      if (els && els.length > 0) return resolve(Array.from(els));
+      if (Date.now() - start > timeout) return reject(new Error("Timeout waiting for elements"));
+      setTimeout(check, interval);
+    };
+
+    check();
+  });
+}
+
 export const wait = (time: number): Promise<void> => new Promise(resolve => setTimeout(resolve, time));


### PR DESCRIPTION
This pull request adds support for retrieving multiple elements at once using a new `getAll` command in the TWD API. It also includes utility and test updates to support and verify this new functionality.

**New API feature:**

* Added a `getAll` method to the `TWDAPI` interface and its implementation in `twd.ts`, allowing users to fetch all elements matching a selector as an array of TWD element APIs. [[1]](diffhunk://#diff-58669bcf1af1a19badc1a011167c2d427124a90220c0349fe48d9ead5d17aab0R82-R95) [[2]](diffhunk://#diff-58669bcf1af1a19badc1a011167c2d427124a90220c0349fe48d9ead5d17aab0R226-R241)

**Utilities:**

* Introduced a new `waitForElements` utility function in `utils/wait.ts` to asynchronously wait for multiple elements to appear in the DOM.
* Updated imports in `twd.ts` to include `waitForElements`.

**Testing:**

* Added an end-to-end test suite in `getAll.spec.ts` to verify the behavior of the new `getAll` command, including cases where elements are found and not found.

This PR closes #35 