### PR TITLE
fix: error with http no content responses

### DIFF
--- a/src/cli/mock-sw.js
+++ b/src/cli/mock-sw.js
@@ -1,5 +1,6 @@
 import { findRule } from './utils/findRule.js';
 import { notifyClients } from './utils/notifyClients.js';
+import { mockResponse } from './utils/mockResponse.js';
 
 /**
  * List of currently active mock rules.
@@ -57,10 +58,11 @@ export const handleFetch = async (event) => {
           notifyClients(clients, rule, body);
         });
 
-        return new Response(JSON.stringify(rule.response), {
-          status: rule.status || 200,
-          headers: rule.responseHeaders || { "Content-Type": "application/json" },
-        });
+        return mockResponse(
+          rule.response,
+          rule.status ?? 200,
+          rule.responseHeaders
+        );
       })()
     );
   }

--- a/src/cli/utils/mockResponse.js
+++ b/src/cli/utils/mockResponse.js
@@ -1,0 +1,27 @@
+
+/**
+ * Mocks a Response object based on the given status and headers.
+ * If the status code does not allow a body, the body will be null.
+ * Otherwise, it will return the rule's response as a JSON string.
+ * @param {unknown} response
+ * @param {number} status
+ * @param {Record<string, string>} [headers]
+ * @returns {Response}
+ */
+export const mockResponse = (response, status, headers) => {
+  // Status codes that cannot have a body
+  const statusCodesWithoutBody = [204, 205, 304];
+  const shouldIncludeBody = !statusCodesWithoutBody.includes(status);
+
+  const body = shouldIncludeBody ? JSON.stringify(response) : null;
+
+  return new Response(
+    body,
+    {
+      status,
+      headers: shouldIncludeBody
+        ? (headers || { "Content-Type": "application/json" })
+        : (headers || {}),
+    }
+  );
+};

--- a/src/tests/cli/response.spec.js
+++ b/src/tests/cli/response.spec.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockResponse } from '../../cli/utils/mockResponse.js';
+
+describe('mockResponse', () => {
+  const responseBody = { message: 'ok' };
+  it('should create a Response with body for status 200', () => {
+    const response = mockResponse(responseBody, 200, { 'Content-Type': 'application/json' });
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    return response.json().then((data) => {
+      expect(data).toEqual(responseBody);
+    });
+  });
+
+  it('should create a Response without body for status 204', () => {
+    const response = mockResponse(responseBody, 204, { 'Content-Type': 'application/json' });
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+    return response.text().then((data) => {
+      expect(data).toBe('');
+    });
+  });
+
+  it('should use default headers if none provided', () => {
+    const response = mockResponse(responseBody, 200);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  });
+});


### PR DESCRIPTION
This pull request refactors how mock HTTP responses are generated and adds dedicated tests for this logic. The main improvement is the introduction of a new utility function, `mockResponse`, which centralizes and standardizes the creation of mock `Response` objects, ensuring correct handling of status codes and headers.

**Refactoring and code reuse:**

* Introduced a new utility function `mockResponse` in `src/cli/utils/mockResponse.js` to handle the creation of `Response` objects, ensuring that status codes which should not have a body (e.g., 204, 205, 304) are handled properly, and headers are set consistently.
* Updated `handleFetch` in `src/cli/mock-sw.js` to use the new `mockResponse` utility instead of manually constructing the `Response` object. [[1]](diffhunk://#diff-49f3a17314f48511a3b2a8349dd5e7ddc2620a2d2949d9703ae207041a9a84daR3) [[2]](diffhunk://#diff-49f3a17314f48511a3b2a8349dd5e7ddc2620a2d2949d9703ae207041a9a84daL60-R65)

**Testing improvements:**

* Added a new test suite in `src/tests/cli/response.spec.js` to verify that `mockResponse` correctly handles different status codes, body presence, and default headers.

This closes #56 