### PR TITLE
fix: error when regex is invalid

### DIFF
--- a/src/cli/utils/findRule.js
+++ b/src/cli/utils/findRule.js
@@ -11,6 +11,15 @@
  * @property {boolean} [urlRegex] - Whether the URL is a regex pattern.
  */
 
+const validRegex = (pattern) => {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Find a matching rule based on method and url
  * @param {string} method
@@ -22,7 +31,7 @@ export function findRule(method, url, rules) {
   return rules.find(
     (r) => {
       const isMethodMatch = r.method.toLowerCase() === method.toLowerCase();
-      if (r.urlRegex) {
+      if (r.urlRegex && validRegex(r.url)) {
         const regex = new RegExp(r.url);
         return isMethodMatch && regex.test(url);
       }

--- a/src/tests/cli/findRule.spec.js
+++ b/src/tests/cli/findRule.spec.js
@@ -30,6 +30,13 @@ describe('findRule', () => {
     expect(findRule('GET', 'https://bar.com', rules)).toBeUndefined();
   });
 
+  it('should not throw for invalid regex', () => {
+    const rules = [
+      { method: 'GET', url: '^https://foo\\.com/([.*$', alias: 'a', urlRegex: true },
+    ];
+    expect(findRule('GET', 'https://foo.com/api', rules)).toBeUndefined();
+  });
+
   it('matches by regex string (wrapped in /.../)', () => {
     const rules = [
       { method: 'GET', url: /users.*/, alias: 'a', urlRegex: true },


### PR DESCRIPTION
This pull request improves the robustness of the `findRule` utility by adding validation for regular expressions and updating its tests to handle invalid regex patterns gracefully. The most important changes are:

### Robustness improvements

* Added a `validRegex` helper function in `src/cli/utils/findRule.js` to check if a given regex pattern is valid before using it.
* Updated the `findRule` function to only attempt regex matching if the pattern is a valid regex, preventing runtime errors from invalid patterns.

### Testing enhancements

* Added a new test case in `src/tests/cli/findRule.spec.js` to ensure that `findRule` does not throw an error when encountering an invalid regex pattern in the rules.

This closes #63 