### PR TITLE
Send testId with mock collection for contract validation

### DIFF
--- a/src/commands/mockBridge.ts
+++ b/src/commands/mockBridge.ts
@@ -140,14 +140,19 @@ export const mockRequest = async (alias: string, options: Options) => {
   else rules.push(rule);
   // Collect mock for contract validation (twd-cli)
   if (typeof window.__twdCollectMock === 'function') {
-    window.__twdCollectMock({
-      alias,
-      url: String(options.url),
-      method: options.method,
-      status: options.status || 200,
-      response: options.response,
-      urlRegex: options.urlRegex || false,
-    });
+    const handlers = window.__TWD_STATE__?.handlers;
+    const running = handlers && [...handlers.values()].find((h: any) => h.status === 'running');
+    if (running) {
+      window.__twdCollectMock({
+        alias,
+        url: String(options.url),
+        method: options.method,
+        status: options.status || 200,
+        response: options.response,
+        urlRegex: options.urlRegex || false,
+        testId: running.id,
+      });
+    }
   }
   // Push to SW
   navigator.serviceWorker.controller?.postMessage({

--- a/src/tests/commands/mockBridge/mockRequest.spec.ts
+++ b/src/tests/commands/mockBridge/mockRequest.spec.ts
@@ -115,6 +115,17 @@ describe('mockBridge mock request methods', () => {
     const collectMock = vi.fn();
     window.__twdCollectMock = collectMock;
 
+    // Set up a running test in TWD state
+    const testId = 'test-abc123';
+    window.__TWD_STATE__ = {
+      handlers: new Map([
+        [testId, { id: testId, name: 'my test', type: 'test', status: 'running', logs: [], depth: 1 }],
+      ]),
+      beforeEachHooks: new Map(),
+      afterEachHooks: new Map(),
+      stack: [],
+    };
+
     const postMessageMock = vi.fn();
     Object.defineProperty(navigator.serviceWorker, 'controller', {
       configurable: true,
@@ -135,14 +146,26 @@ describe('mockBridge mock request methods', () => {
       status: 201,
       response: { id: 1 },
       urlRegex: false,
+      testId: testId,
     });
 
     delete window.__twdCollectMock;
+    delete window.__TWD_STATE__;
   });
 
   it('should call __twdCollectMock with urlRegex when provided', async () => {
     const collectMock = vi.fn();
     window.__twdCollectMock = collectMock;
+
+    const testId = 'test-regex456';
+    window.__TWD_STATE__ = {
+      handlers: new Map([
+        [testId, { id: testId, name: 'regex test', type: 'test', status: 'running', logs: [], depth: 1 }],
+      ]),
+      beforeEachHooks: new Map(),
+      afterEachHooks: new Map(),
+      stack: [],
+    };
 
     const postMessageMock = vi.fn();
     Object.defineProperty(navigator.serviceWorker, 'controller', {
@@ -165,8 +188,73 @@ describe('mockBridge mock request methods', () => {
       status: 200,
       response: [],
       urlRegex: true,
+      testId: testId,
     });
 
     delete window.__twdCollectMock;
+    delete window.__TWD_STATE__;
+  });
+
+  it('should not call __twdCollectMock when no test is running', async () => {
+    const collectMock = vi.fn();
+    window.__twdCollectMock = collectMock;
+
+    // Set up TWD state with no running test
+    window.__TWD_STATE__ = {
+      handlers: new Map([
+        ['idle-test', { id: 'idle-test', name: 'idle test', type: 'test', status: 'idle', logs: [], depth: 1 }],
+      ]),
+      beforeEachHooks: new Map(),
+      afterEachHooks: new Map(),
+      stack: [],
+    };
+
+    const postMessageMock = vi.fn();
+    Object.defineProperty(navigator.serviceWorker, 'controller', {
+      configurable: true,
+      get: () => ({ postMessage: postMessageMock }),
+    });
+
+    await mockRequest('orphanAlias', {
+      url: 'https://api.example.com/orphan',
+      method: 'GET',
+      status: 200,
+      response: {},
+    });
+
+    expect(collectMock).not.toHaveBeenCalled();
+
+    // Service worker messaging still works
+    expect(postMessageMock).toHaveBeenCalled();
+
+    delete window.__twdCollectMock;
+    delete window.__TWD_STATE__;
+  });
+
+  it('should not call __twdCollectMock when __TWD_STATE__ is not available', async () => {
+    const collectMock = vi.fn();
+    window.__twdCollectMock = collectMock;
+
+    const originalState = window.__TWD_STATE__;
+    delete window.__TWD_STATE__;
+
+    const postMessageMock = vi.fn();
+    Object.defineProperty(navigator.serviceWorker, 'controller', {
+      configurable: true,
+      get: () => ({ postMessage: postMessageMock }),
+    });
+
+    await mockRequest('noStateAlias', {
+      url: 'https://api.example.com/nostate',
+      method: 'GET',
+      status: 200,
+      response: {},
+    });
+
+    expect(collectMock).not.toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalled();
+
+    delete window.__twdCollectMock;
+    if (originalState) window.__TWD_STATE__ = originalState;
   });
 });


### PR DESCRIPTION
## Summary

Add testId to the __twdCollectMock payload so twd-cli can identify which test registered each mock. This enables contract validation to:
- Distinguish mocks with the same alias registered across different tests  
- Show which test caused a contract validation failure
- Track how many times the same alias is used within a single test

## Changes

- Find the currently running test by scanning window.__TWD_STATE__.handlers for status === 'running'
- Include its id in the __twdCollectMock payload as testId field
- Only call __twdCollectMock when a test is actually running (guard on running status)
- Updated 2 existing tests to set up running handler and expect testId
- Added 2 new tests for guard condition (no collection when test not running)

## Mock Payload

The __twdCollectMock function now receives:
```javascript
{
  alias: string,
  url: string,
  method: string,
  status: number,
  response: unknown,
  urlRegex: boolean,
  testId: string  // NEW — handler ID from window.__TWD_STATE__.handlers
}
```

## Testing

- All 354 tests passing
- No regressions
- 4 new tests for testId payload and guard conditions

## Related

Paired with twd-cli PR: Fix mock overlap in contract validation (feat/fix-mock-overlap branch)

## Backward Compatibility

- Consumers of __twdCollectMock that don't expect testId will simply ignore the extra field
- If twd-cli is on an older version that doesn't read testId, nothing breaks
- If twd-js is on an older version that doesn't send testId, twd-cli handles gracefully