### PR TITLE
feat: add unfocused tab fallbacks for clear() and keyboard() in userEvent proxy

### DIFF
--- a/src/proxies/userEvent.ts
+++ b/src/proxies/userEvent.ts
@@ -31,6 +31,14 @@ function typingFallback(element: HTMLElement, text: string) {
   element.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
+/**
+ * Fallback for userEvent.clear() when the browser tab is not in focus.
+ * Reuses the native value setter pattern from typingFallback with an empty string.
+ */
+function clearFallback(element: HTMLElement) {
+  typingFallback(element, '');
+}
+
 function createLoggedProxy(obj: any, prefix = 'userEvent') {
   return new Proxy(obj, {
     get(target, prop, receiver) {
@@ -51,6 +59,41 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
         return async (...args: any[]) => {
           if (document.visibilityState === 'hidden' || !document.hasFocus()) {
             typingFallback(args[0], args[1]);
+            log(eventsMessage(prefix, prop, args));
+            return;
+          }
+          const result = await orig(...args);
+          log(eventsMessage(prefix, prop, args));
+          return result;
+        };
+      }
+
+      // Fallback for clear() when tab is not in focus
+      if (prop === 'clear') {
+        return async (...args: any[]) => {
+          if (document.visibilityState === 'hidden' || !document.hasFocus()) {
+            clearFallback(args[0]);
+            log(eventsMessage(prefix, prop, args));
+            return;
+          }
+          const result = await orig(...args);
+          log(eventsMessage(prefix, prop, args));
+          return result;
+        };
+      }
+
+      // Fallback for keyboard() when tab is not in focus
+      if (prop === 'keyboard') {
+        return async (...args: any[]) => {
+          if (document.visibilityState === 'hidden' || !document.hasFocus()) {
+            const keys = args[0] as string;
+            if (keys === '{Tab}') {
+              const active = document.activeElement as HTMLElement;
+              if (active) {
+                active.dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+                active.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+              }
+            }
             log(eventsMessage(prefix, prop, args));
             return;
           }

--- a/src/tests/proxies/userEvent.spec.ts
+++ b/src/tests/proxies/userEvent.spec.ts
@@ -113,3 +113,178 @@ describe('userEvent typing fallback', () => {
     document.body.removeChild(input);
   });
 });
+
+describe('userEvent clear fallback', () => {
+  let originalVisibilityState: PropertyDescriptor | undefined;
+  let hasFocusSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    twd.handlers.clear();
+    originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+    hasFocusSpy = vi.spyOn(document, 'hasFocus');
+  });
+
+  afterEach(() => {
+    if (originalVisibilityState) {
+      Object.defineProperty(document, 'visibilityState', originalVisibilityState);
+    } else {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible',
+      });
+    }
+    hasFocusSpy.mockRestore();
+  });
+
+  it('should clear input value and dispatch events when document is hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input');
+    input.value = 'existing text';
+    document.body.appendChild(input);
+
+    const inputHandler = vi.fn();
+    const changeHandler = vi.fn();
+    input.addEventListener('input', inputHandler);
+    input.addEventListener('change', changeHandler);
+
+    twd.describe('Clear fallback hidden', () => {
+      twd.it('clears via fallback', async () => {
+        await userEvent.clear(input);
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    expect(input.value).toBe('');
+    expect(inputHandler).toHaveBeenCalled();
+    expect(changeHandler).toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('should clear input value when document has no focus but is visible', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input');
+    input.value = 'some text';
+    document.body.appendChild(input);
+
+    twd.describe('Clear fallback unfocused', () => {
+      twd.it('clears via fallback', async () => {
+        await userEvent.clear(input);
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    expect(input.value).toBe('');
+
+    document.body.removeChild(input);
+  });
+});
+
+describe('userEvent keyboard fallback', () => {
+  let originalVisibilityState: PropertyDescriptor | undefined;
+  let hasFocusSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    twd.handlers.clear();
+    originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+    hasFocusSpy = vi.spyOn(document, 'hasFocus');
+  });
+
+  afterEach(() => {
+    if (originalVisibilityState) {
+      Object.defineProperty(document, 'visibilityState', originalVisibilityState);
+    } else {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible',
+      });
+    }
+    hasFocusSpy.mockRestore();
+  });
+
+  it('should dispatch blur and focusout when pressing Tab and document is hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const blurHandler = vi.fn();
+    const focusoutHandler = vi.fn();
+    input.addEventListener('blur', blurHandler);
+    input.addEventListener('focusout', focusoutHandler);
+
+    twd.describe('Keyboard Tab fallback hidden', () => {
+      twd.it('dispatches blur via fallback', async () => {
+        await userEvent.keyboard('{Tab}');
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    expect(blurHandler).toHaveBeenCalled();
+    expect(focusoutHandler).toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it('should dispatch blur and focusout when pressing Tab and document has no focus', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const blurHandler = vi.fn();
+    const focusoutHandler = vi.fn();
+    input.addEventListener('blur', blurHandler);
+    input.addEventListener('focusout', focusoutHandler);
+
+    twd.describe('Keyboard Tab fallback unfocused', () => {
+      twd.it('dispatches blur via fallback', async () => {
+        await userEvent.keyboard('{Tab}');
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    expect(blurHandler).toHaveBeenCalled();
+    expect(focusoutHandler).toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `clearFallback` helper that reuses `typingFallback` with an empty string, avoiding code duplication
- Adds unfocused fallback for `clear()` — uses native value setter to set `""` and dispatches `input`/`change` events so React picks up the change when the tab is backgrounded
- Adds unfocused fallback for `keyboard('{Tab}')` — dispatches `blur` + `focusout` on `document.activeElement` to trigger framework validation (e.g. React Hook Form) when the tab is not focused

Fixes flaky tests in the AI relay workflow where the browser tab loses focus during full suite runs via twd-relay.

## Test plan

- [ ] Red/green TDD cycle followed — tests were written against commented-out implementation, confirmed failing, then implementation was uncommented
- [ ] 4 new tests covering `clear` and `keyboard` fallbacks for both `hidden` and `no-focus` scenarios
- [ ] All 354 tests pass (`npm run test:ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)