### PR TITLE
fix(userEvent): add unfocused tab fallbacks for keyboard(), clear() and blur

### DIFF
--- a/examples/twd-test-app/src/pages/BlurValidation.tsx
+++ b/examples/twd-test-app/src/pages/BlurValidation.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+const BlurValidation: React.FC = () => {
+  const [firstName, setFirstName] = useState('');
+  const [firstNameError, setFirstNameError] = useState('');
+
+  const handleFirstNameBlur = () => {
+    if (!firstName.trim()) {
+      setFirstNameError('First name is required');
+    } else {
+      setFirstNameError('');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 480, margin: '2rem auto', padding: '2rem' }}>
+      <h2>Blur Validation</h2>
+      <p>
+        This page tests that blur-triggered validation works correctly even when
+        the browser tab is not focused (e.g. during automated twd-relay runs).
+      </p>
+      <form>
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="first-name">First name:</label>
+          <br />
+          <input
+            id="first-name"
+            type="text"
+            value={firstName}
+            onChange={e => setFirstName(e.target.value)}
+            onBlur={handleFirstNameBlur}
+            aria-describedby={firstNameError ? 'first-name-error' : undefined}
+            style={{ width: '100%', padding: '0.5rem' }}
+          />
+          {firstNameError && (
+            <span
+              id="first-name-error"
+              role="alert"
+              style={{ color: 'red', fontSize: '0.875rem' }}
+            >
+              {firstNameError}
+            </span>
+          )}
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="last-name">Last name:</label>
+          <br />
+          <input
+            id="last-name"
+            type="text"
+            style={{ width: '100%', padding: '0.5rem' }}
+          />
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default BlurValidation;

--- a/examples/twd-test-app/src/pages/ComboboxSelect.tsx
+++ b/examples/twd-test-app/src/pages/ComboboxSelect.tsx
@@ -1,0 +1,122 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+const COUNTRIES = ['Spain', 'France', 'Germany', 'Italy', 'Portugal', 'United States', 'United Kingdom'];
+
+/**
+ * Minimal combobox component that mirrors the pattern used in real apps
+ * (e.g. phone-code selectors): a button opens a filter input + list,
+ * keyboard arrow keys navigate, Enter selects.
+ *
+ * Used to verify that userEvent.keyboard("Spain{arrowdown}{enter}") works
+ * correctly even when the browser tab is not focused.
+ */
+const ComboboxSelect: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+  const [selected, setSelected] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const filterRef = useRef<HTMLInputElement>(null);
+
+  const filtered = COUNTRIES.filter(c =>
+    c.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  useEffect(() => {
+    if (open && filterRef.current) {
+      filterRef.current.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [filter]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      setHighlightedIndex(i => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      setHighlightedIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      if (filtered[highlightedIndex]) {
+        setSelected(filtered[highlightedIndex]);
+        setOpen(false);
+        setFilter('');
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setFilter('');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 480, margin: '2rem auto', padding: '2rem' }}>
+      <h2>Combobox Select</h2>
+      <p>
+        Tests that <code>userEvent.keyboard("Spain&#123;arrowdown&#125;&#123;enter&#125;")</code>{' '}
+        works when the browser window is not focused.
+      </p>
+
+      <div style={{ position: 'relative', display: 'inline-block' }}>
+        <button
+          onClick={() => setOpen(o => !o)}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          style={{ padding: '0.5rem 1rem' }}
+        >
+          {selected || 'Select country'}
+        </button>
+
+        {open && (
+          <div
+            style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              border: '1px solid #ccc',
+              background: '#1a1a2e',
+              zIndex: 10,
+              minWidth: 200,
+              borderRadius: 4,
+            }}
+          >
+            <input
+              ref={filterRef}
+              type="text"
+              placeholder="Filter…"
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+              onKeyDown={handleKeyDown}
+              aria-label="Filter countries"
+              style={{ width: '100%', padding: '0.5rem', boxSizing: 'border-box' }}
+            />
+            <ul role="listbox" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+              {filtered.map((country, i) => (
+                <li
+                  key={country}
+                  role="option"
+                  aria-selected={i === highlightedIndex}
+                  onClick={() => { setSelected(country); setOpen(false); setFilter(''); }}
+                  style={{
+                    padding: '0.4rem 0.75rem',
+                    background: i === highlightedIndex ? '#333' : 'transparent',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {country}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <p data-testid="selected-country" style={{ marginTop: '1rem' }}>
+          Selected: <strong>{selected}</strong>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ComboboxSelect;

--- a/examples/twd-test-app/src/routes.tsx
+++ b/examples/twd-test-app/src/routes.tsx
@@ -6,6 +6,8 @@ import { LoadShows } from "./pages/LoadShows";
 import ScreenQueries from "./pages/ScreenQueries";
 import MockComponent from "./pages/MockComponent";
 import Responsive from "./pages/Responsive";
+import BlurValidation from "./pages/BlurValidation";
+import ComboboxSelect from "./pages/ComboboxSelect";
 
 const router = createBrowserRouter([
   {
@@ -35,6 +37,14 @@ const router = createBrowserRouter([
   {
     path: '/responsive',
     Component: Responsive,
+  },
+  {
+    path: '/blur-validation',
+    Component: BlurValidation,
+  },
+  {
+    path: '/combobox-select',
+    Component: ComboboxSelect,
   },
   {
     path: "*",

--- a/examples/twd-test-app/src/twd-tests/blur-validation.twd.test.ts
+++ b/examples/twd-test-app/src/twd-tests/blur-validation.twd.test.ts
@@ -1,0 +1,46 @@
+import { twd, expect, userEvent, screenDom } from "../../../../src";
+import { describe, it, afterEach } from "../../../../src/runner";
+
+/**
+ * These tests verify that blur-triggered validation and keyboard interactions
+ * work correctly even when the browser tab is not focused — which is the
+ * common case during automated twd-relay runs when the AI agent is active
+ * while the user has another window open.
+ *
+ * `window.blur()` is used to programmatically remove window focus, simulating
+ * the unfocused-tab condition that triggers the fallback paths in userEvent.
+ */
+describe("Blur validation — unfocused tab fallback", () => {
+  afterEach(() => {
+    // Restore window focus after each test so other tests are not affected.
+    window.focus();
+  });
+
+  it("shows validation error after type, clear and Tab when window is not focused", async () => {
+    await twd.visit("/blur-validation");
+
+    // Simulate the tab losing focus — as happens when the AI relay runs tests
+    // while the user has another window in the foreground.
+    window.blur();
+
+    const input = await screenDom.findByLabelText("First name:");
+
+    // type something, then clear it — field is now empty (required)
+    await userEvent.type(input, "a");
+    await userEvent.clear(input);
+
+    // Tab away — must trigger onBlur even though window has no focus.
+    // Without the fix: typingFallback calls element.focus() but browsers
+    // suppress focus/focusin DOM events in unfocused tabs. React never learns
+    // the element is focused, so when keyboard("{Tab}") dispatches focusout,
+    // React does not fire onBlur → validation never runs → this assertion fails.
+    await userEvent.keyboard("{Tab}");
+
+    // onBlur validation sets aria-describedby when the field is invalid
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).to.equal("first-name-error");
+
+    const errorMsg = await screenDom.findByRole("alert");
+    expect(errorMsg.textContent).to.equal("First name is required");
+  });
+});

--- a/examples/twd-test-app/src/twd-tests/combobox-select.twd.test.ts
+++ b/examples/twd-test-app/src/twd-tests/combobox-select.twd.test.ts
@@ -1,0 +1,41 @@
+import { twd, expect, userEvent, screenDom } from "../../../../src";
+import { describe, it, afterEach } from "../../../../src/runner";
+
+/**
+ * Tests that keyboard interactions inside a combobox (type to filter →
+ * ArrowDown → Enter) work when the browser window is not focused.
+ *
+ * This reproduces the pattern used by selectPhoneCode() in real apps:
+ *   await userEvent.click(triggerButton);
+ *   await userEvent.keyboard(`${country}{arrowdown}{enter}`);
+ *
+ * Before the fix, keyboard() with non-Tab keys was a complete no-op when the
+ * tab was unfocused: the dropdown filter was never typed into, the arrow key
+ * never fired, and Enter never selected — leaving the dropdown open and
+ * blocking subsequent interactions (pointer-events: none errors).
+ */
+describe("Combobox select — unfocused tab fallback", () => {
+  afterEach(() => {
+    window.focus();
+  });
+
+  it("selects a country via keyboard filter+arrow+enter when window is not focused", async () => {
+    await twd.visit("/combobox-select");
+
+    // Simulate the window losing focus — same condition as twd-relay runs
+    window.blur();
+
+    // Open the combobox
+    const trigger = await screenDom.findByRole("button", { name: /select country/i });
+    await userEvent.click(trigger);
+
+    // Type to filter, arrow down to first result, enter to select.
+    // Without the fix this is a no-op: the dropdown stays open with nothing
+    // selected, and later clicks fail with pointer-events: none errors.
+    await userEvent.keyboard("Spain{arrowdown}{enter}");
+
+    // The selected value should be visible
+    const result = await screenDom.findByTestId("selected-country");
+    expect(result.textContent).to.include("Spain");
+  });
+});

--- a/src/proxies/userEvent.ts
+++ b/src/proxies/userEvent.ts
@@ -5,12 +5,74 @@ import { eventsMessage } from './eventsMessage';
 type UserEvent = typeof userEventLib;
 
 /**
+ * Maps userEvent key syntax to DOM KeyboardEvent.key values.
+ * Keys are lowercased for case-insensitive matching.
+ */
+const KEY_MAP: Record<string, string> = {
+  '{arrowdown}': 'ArrowDown',
+  '{arrowup}': 'ArrowUp',
+  '{arrowleft}': 'ArrowLeft',
+  '{arrowright}': 'ArrowRight',
+  '{enter}': 'Enter',
+  '{escape}': 'Escape',
+  '{esc}': 'Escape',
+  '{tab}': 'Tab',
+  '{space}': ' ',
+  '{backspace}': 'Backspace',
+  '{delete}': 'Delete',
+  '{del}': 'Delete',
+  '{home}': 'Home',
+  '{end}': 'End',
+  '{pageup}': 'PageUp',
+  '{pagedown}': 'PageDown',
+};
+
+/**
+ * Parses a userEvent key string into individual tokens.
+ * Special keys like {arrowdown} are kept as-is; regular characters are
+ * returned one per token.
+ *
+ * e.g. "Spain{arrowdown}{enter}" → ["S","p","a","i","n","{arrowdown}","{enter}"]
+ */
+function parseKeys(keys: string): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < keys.length) {
+    if (keys[i] === '{') {
+      const end = keys.indexOf('}', i);
+      if (end !== -1) {
+        tokens.push(keys.slice(i, end + 1));
+        i = end + 1;
+      } else {
+        tokens.push(keys[i]);
+        i++;
+      }
+    } else {
+      tokens.push(keys[i]);
+      i++;
+    }
+  }
+  return tokens;
+}
+
+/**
  * Fallback for userEvent.type() when the browser tab is not in focus.
  * Uses the native value setter to trigger React's controlled input update,
- * then dispatches input/change events so frameworks pick up the change.
+ * then dispatches focus/focusin so React's event delegation registers the
+ * element as focused (browsers suppress these events in unfocused tabs),
+ * followed by input/change events so frameworks pick up the change.
+ *
+ * The explicit focus/focusin dispatch is required because React 17+ uses
+ * focusin (bubbling) for synthetic onFocus/onBlur tracking via event
+ * delegation at the root. Without it, React won't fire onBlur when focusout
+ * is later dispatched (e.g. from the keyboard "{Tab}" fallback).
  */
 function typingFallback(element: HTMLElement, text: string) {
   element.focus();
+  // Browsers suppress focus/focusin events when the tab is not focused.
+  // Dispatch them explicitly so React's event delegation tracks this element.
+  element.dispatchEvent(new FocusEvent('focus', { bubbles: false, cancelable: false }));
+  element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, cancelable: false }));
 
   const isInput = element instanceof HTMLInputElement;
   const isTextarea = element instanceof HTMLTextAreaElement;
@@ -82,18 +144,60 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
         };
       }
 
-      // Fallback for keyboard() when tab is not in focus
+      // Fallback for keyboard() when tab is not in focus.
+      //
+      // The real userEvent.keyboard() relies on actual browser focus and
+      // interaction events that get deprioritized when the tab is backgrounded.
+      // This fallback parses the key string and dispatches synthetic events
+      // for each token:
+      //   - Regular characters: appended to the active element's value via
+      //     typingFallback (native setter + input/change events)
+      //   - {Tab}: blur + focusout on the active element
+      //   - Arrow keys, Enter, Escape, etc.: keydown + keyup events
+      //   - {Backspace}: removes the last character from the element value
       if (prop === 'keyboard') {
         return async (...args: any[]) => {
           if (document.visibilityState === 'hidden' || !document.hasFocus()) {
             const keys = args[0] as string;
-            if (keys === '{Tab}') {
-              const active = document.activeElement as HTMLElement;
-              if (active) {
+            const tokens = parseKeys(keys);
+            const active = document.activeElement as HTMLElement;
+
+            if (!active || active === document.body) {
+              log(eventsMessage(prefix, prop, args));
+              return;
+            }
+
+            let textBuffer = '';
+
+            const flushText = () => {
+              if (!textBuffer) return;
+              const currentValue = (active as HTMLInputElement).value ?? '';
+              typingFallback(active, currentValue + textBuffer);
+              textBuffer = '';
+            };
+
+            for (const token of tokens) {
+              const mappedKey = KEY_MAP[token.toLowerCase()];
+
+              if (mappedKey === 'Tab') {
+                flushText();
                 active.dispatchEvent(new FocusEvent('blur', { bubbles: true }));
                 active.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+              } else if (mappedKey === 'Backspace') {
+                flushText();
+                const currentValue = (active as HTMLInputElement).value ?? '';
+                typingFallback(active, currentValue.slice(0, -1));
+              } else if (mappedKey) {
+                flushText();
+                active.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: mappedKey }));
+                active.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, cancelable: true, key: mappedKey }));
+              } else {
+                // Regular character — accumulate for a single flush
+                textBuffer += token;
               }
             }
+
+            flushText();
             log(eventsMessage(prefix, prop, args));
             return;
           }

--- a/src/tests/proxies/userEvent.spec.ts
+++ b/src/tests/proxies/userEvent.spec.ts
@@ -287,4 +287,124 @@ describe('userEvent keyboard fallback', () => {
 
     document.body.removeChild(input);
   });
+
+  // Regression: when keyboard("{Tab}") is called after type() in fallback mode,
+  // blur must fire on the input even though input.focus() was never called
+  // manually. Before the fix, typingFallback did not dispatch focus/focusin, so
+  // React's event delegation didn't know the element was focused and would not
+  // fire onBlur when focusout arrived.
+  it('should dispatch blur on the input after type() fallback without manual focus call', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    // NOTE: input.focus() is intentionally NOT called here — simulating the
+    // real relay scenario where keyboard("{Tab}") follows userEvent.type().
+
+    const focusinHandler = vi.fn();
+    const blurHandler = vi.fn();
+    const focusoutHandler = vi.fn();
+    input.addEventListener('focusin', focusinHandler);
+    input.addEventListener('blur', blurHandler);
+    input.addEventListener('focusout', focusoutHandler);
+
+    twd.describe('Tab after type without manual focus', () => {
+      twd.it('dispatches blur after type fallback', async () => {
+        await userEvent.type(input, 'hello');
+        await userEvent.keyboard('{Tab}');
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    // typingFallback must have dispatched focusin so that React knows the
+    // element is focused before focusout arrives.
+    expect(focusinHandler).toHaveBeenCalled();
+    expect(blurHandler).toHaveBeenCalled();
+    expect(focusoutHandler).toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  // Regression: keyboard() with non-Tab keys (e.g. "Spain{arrowdown}{enter}")
+  // was a complete no-op when the tab was not focused. This caused combobox
+  // interactions (type to filter → arrow-select → enter) to silently fail,
+  // leaving the dropdown open and blocking subsequent clicks.
+  it('should dispatch keydown events for arrow and enter keys when document is hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const keydownHandler = vi.fn();
+    input.addEventListener('keydown', keydownHandler);
+
+    twd.describe('Keyboard non-Tab fallback hidden', () => {
+      twd.it('dispatches keydown for arrow and enter', async () => {
+        await userEvent.keyboard('{arrowdown}{enter}');
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    const keys = keydownHandler.mock.calls.map((c: any[]) => (c[0] as KeyboardEvent).key);
+    expect(keys).toContain('ArrowDown');
+    expect(keys).toContain('Enter');
+
+    document.body.removeChild(input);
+  });
+
+  it('should type text characters and dispatch keydown for special keys in a mixed key string', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    hasFocusSpy.mockReturnValue(false);
+
+    const input = document.createElement('input') as HTMLInputElement;
+    document.body.appendChild(input);
+    input.focus();
+
+    const inputHandler = vi.fn();
+    const keydownHandler = vi.fn();
+    input.addEventListener('input', inputHandler);
+    input.addEventListener('keydown', keydownHandler);
+
+    twd.describe('Mixed keys fallback hidden', () => {
+      twd.it('types text then dispatches arrow+enter', async () => {
+        await userEvent.keyboard('Spain{arrowdown}{enter}');
+      });
+    });
+
+    const testArray = Array.from(twd.handlers.values());
+    const test = testArray[testArray.length - 1];
+    test.status = 'running';
+    await test.handler();
+
+    // Text characters must have been flushed as a value update
+    expect(input.value).toBe('Spain');
+    expect(inputHandler).toHaveBeenCalled();
+
+    // Special keys must have fired keydown events
+    const keys = keydownHandler.mock.calls.map((c: any[]) => (c[0] as KeyboardEvent).key);
+    expect(keys).toContain('ArrowDown');
+    expect(keys).toContain('Enter');
+
+    document.body.removeChild(input);
+  });
 });


### PR DESCRIPTION
## Summary

- **`typingFallback`** now explicitly dispatches `focus`/`focusin` after `element.focus()`. Browsers suppress these events in unfocused tabs so React's event delegation never registered the element as focused — meaning `focusout` from `keyboard("{Tab}")` produced no synthetic `onBlur` and blur-triggered validation (e.g. React Hook Form) never ran.
- **`keyboard()` fallback** now handles the full key string instead of only `{Tab}`: regular characters are buffered and flushed via `typingFallback` (native setter + `input`/`change` events); arrow keys, `Enter`, `Escape` etc. dispatch real `keydown`/`keyup` events; `{Backspace}` trims the value. This fixes combobox patterns like `keyboard("Spain{arrowdown}{enter}")` that were silently dropped, leaving dropdowns open and blocking subsequent clicks (`pointer-events: none` cascade).

## Test Plan

- [ ] 3 new Vitest unit tests — confirmed RED before fix, GREEN after (`npm test src/tests/proxies/userEvent.spec.ts`)
- [ ] Full suite clean: 361 tests, 0 failures (`npm run test:ci`)
- [ ] `examples/twd-test-app`: new `/blur-validation` page + test — `window.blur()` → `type` → `clear` → `keyboard("{Tab}")` → validates `aria-describedby` is set
- [ ] `examples/twd-test-app`: new `/combobox-select` page + test — `window.blur()` → `click` trigger → `keyboard("Spain{arrowdown}{enter}")` → validates selected country shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)