### PR TITLE
feat(waitFor): make generic to return callback value

### DIFF
--- a/ai-guides/TWD_PROMPT.md
+++ b/ai-guides/TWD_PROMPT.md
@@ -180,6 +180,21 @@ await twd.visit("/users?page=2");
 // Wait for time
 await twd.wait(1000); // 1 second
 
+// Wait for a condition (preferred over twd.wait for retry logic)
+// ONLY use waitFor when you need retry logic (async rendering, delayed events)
+await twd.waitFor(() => {
+  const event = findEvent("purchase");
+  expect(event).to.exist;
+});
+
+// waitFor returns the callback's value
+const event = await twd.waitFor(() => {
+  const ev = findEvent("purchase");
+  expect(ev).to.exist;
+  return ev;
+});
+expect(event.customer_type).to.equal("b2c");
+
 // Wait for element to appear (Testing Library)
 const element = await screenDom.findByText("Success!");
 
@@ -512,6 +527,8 @@ export default { fetchData };
 | Assert visible | `element.should("be.visible")` |
 | Mock request | `await twd.mockRequest("alias", { method, url, response })` |
 | Wait for request | `await twd.waitForRequest("alias")` |
+| Wait for condition | `await twd.waitFor(() => expect(el).to.have.attribute("loaded", "true"))` |
+| Wait & return value | `const el = await twd.waitFor(() => screenDom.getByRole("button"))` |
 | Check mock hit count | `twd.getRequestCount("alias")` |
 | All mock hit counts | `twd.getRequestCounts()` |
 | Clear mocks | `twd.clearRequestMockRules()` |

--- a/docs/api/twd-commands.md
+++ b/docs/api/twd-commands.md
@@ -461,22 +461,24 @@ For condition-based waiting (waiting for an element to change, an event to fire,
 
 Retries a callback until it stops throwing or the timeout expires. Use this instead of `twd.wait(ms)` to avoid blind delays — `waitFor` resolves as soon as your condition is met, making tests faster and more reliable.
 
+If the callback returns a value, `waitFor` resolves with that value — useful for extracting elements or data without nesting all assertions inside the callback.
+
 #### Syntax
 
 ```ts
-twd.waitFor(
-  callback: () => void | Promise<void>,
+twd.waitFor<T>(
+  callback: () => T | Promise<T>,
   options?: {
     timeout?: number;   // Default: 2000
     interval?: number;  // Default: 50
     message?: string;
   }
-): Promise<void>
+): Promise<T>
 ```
 
 #### Parameters
 
-- **callback** (`() => void | Promise<void>`) - Function to retry. Should throw if the condition is not yet met. Can be sync or async.
+- **callback** (`() => T | Promise<T>`) - Function to retry. Should throw if the condition is not yet met. Can be sync or async. If it returns a value, `waitFor` resolves with that value.
 - **options** (`object`, optional):
   - **timeout** (`number`) - Max time to wait in milliseconds. Default: `2000`
   - **interval** (`number`) - Poll interval in milliseconds. Default: `50`
@@ -484,7 +486,7 @@ twd.waitFor(
 
 #### Returns
 
-`Promise<void>` - Resolves when the callback succeeds. Rejects with a timeout error if the callback keeps throwing past the timeout.
+`Promise<T>` - Resolves with the callback's return value when it succeeds. If the callback returns `void`, resolves as `Promise<void>`. Rejects with a timeout error if the callback keeps throwing past the timeout.
 
 #### Error Format
 
@@ -501,17 +503,22 @@ Last error: expected undefined to exist
 #### Examples
 
 ```ts
-// DOM assertion - wait for attribute to update
-const heading = await screenDom.findByText("Checkout");
+// Return an element — single expression
+const heading = await twd.waitFor(() => screenDom.getByRole("heading", { name: /checkout/i }));
+twd.should(heading, "be.visible");
+
+// Return a value with assertions inside
+const event = await twd.waitFor(() => {
+  const ev = findEvent("purchase");
+  expect(ev).to.exist;
+  return ev;
+}, { message: "purchase event to fire" });
+expect(event.customer_type).to.equal("b2c");
+
+// Fire-and-forget (void) — works exactly as before
 await twd.waitFor(() => {
   expect(heading).to.have.attribute("data-loaded", "true");
 });
-
-// Analytics event - wait for dataLayer event to fire
-await twd.waitFor(() => {
-  const event = findEvent("purchase"); // your analytics helper
-  expect(event).to.exist;
-}, { message: "purchase event to fire" });
 
 // Custom timeout for slow operations
 await twd.waitFor(() => {
@@ -534,7 +541,22 @@ await twd.waitFor(() => {
 | **Resolves when** | Callback stops throwing | Fixed time elapses |
 | **Speed** | As fast as the condition is met | Always waits the full duration |
 | **Reliability** | Adapts to timing variations | Fails if operation is slower than the wait |
+| **Returns** | The callback's return value | `void` |
 | **Use for** | Any async condition (DOM, events, state) | Intentional delays (animations, debounce testing) |
+
+::: warning Only use waitFor when retry logic is necessary
+`waitFor` is a polling utility — it retries the callback repeatedly until it passes. Don't use it as a general-purpose wrapper. If you already have the element or value and just need to assert on it, assert directly.
+
+```ts
+// DON'T — no retry needed, getByRole throws synchronously if not found
+const heading = await twd.waitFor(() => screenDom.getByRole("heading"));
+
+// DO — use waitFor when the element might not exist yet (async rendering, delayed state)
+const heading = await twd.waitFor(() => screenDom.getByRole("heading", { name: /loaded/i }));
+```
+
+Use `waitFor` for: analytics events that fire asynchronously, DOM attributes that update after an async operation, elements that appear after a delay.
+:::
 
 ::: tip Prefer waitFor over twd.wait
 Most uses of `twd.wait(ms)` can be replaced with `twd.waitFor()`. The callback should be a **pure check** — don't perform actions inside it, only assertions or reads.

--- a/examples/twd-test-app/src/twd-tests/screen-queries.twd.test.ts
+++ b/examples/twd-test-app/src/twd-tests/screen-queries.twd.test.ts
@@ -162,5 +162,12 @@ describe("Screen Queries Demo", () => {
     const allHeadings = screenDom.getAllByRole("heading");
     expect(allHeadings.length).to.be.greaterThan(2);
   });
+
+  it("should return a value from twd.waitFor", async () => {
+    await twd.visit("/screen-queries");
+
+    const heading = await twd.waitFor(() => screenDom.getByRole("heading", { name: /screen queries demo/i }));
+    twd.should(heading, "be.visible");
+  });
 });
 

--- a/src/tests/utils/waitFor.spec.ts
+++ b/src/tests/utils/waitFor.spec.ts
@@ -101,4 +101,24 @@ describe('waitFor', () => {
       vi.useRealTimers();
     }
   });
+
+  it('returns the callback value when it succeeds', async () => {
+    const result = await waitFor(() => 42);
+    expect(result).toBe(42);
+  });
+
+  it('returns the callback value from an async callback', async () => {
+    const result = await waitFor(async () => ({ name: 'test' }));
+    expect(result).toEqual({ name: 'test' });
+  });
+
+  it('returns the value from the successful retry', async () => {
+    let count = 0;
+    const result = await waitFor(() => {
+      count++;
+      if (count < 3) throw new Error('not yet');
+      return `attempt-${count}`;
+    }, { interval: 10 });
+    expect(result).toBe('attempt-3');
+  });
 });

--- a/src/twd.ts
+++ b/src/twd.ts
@@ -196,24 +196,27 @@ interface TWDAPI {
    *
    * @param callback Function to retry — can be sync or async. Should throw if the condition is not yet met.
    * @param options Optional timeout, interval, and message settings
-   * @returns A promise that resolves when the callback succeeds
+   * @returns A promise that resolves with the callback's return value when it succeeds
    *
    * @example
    * ```ts
-   * // Wait for an analytics event
-   * await twd.waitFor(() => {
-   *   const event = findEvent("purchase");
-   *   expect(event).to.exist;
+   * // Wait for an analytics event and return it
+   * const event = await twd.waitFor(() => {
+   *   const ev = findEvent("purchase");
+   *   expect(ev).to.exist;
+   *   return ev;
    * }, { message: "purchase event to fire" });
    *
-   * // Wait with custom timeout
+   * // Wait for an element (single expression)
+   * const heading = await twd.waitFor(() => screenDom.getByRole("heading", { name: /checkout/i }));
+   *
+   * // Fire-and-forget (void) — still works as before
    * await twd.waitFor(() => {
-   *   const el = document.querySelector(".loaded");
-   *   if (!el) throw new Error("not loaded");
-   * }, { timeout: 5000 });
+   *   expect(submitButton.disabled).to.be.false;
+   * });
    * ```
    */
-  waitFor: (callback: () => void | Promise<void>, options?: WaitForOptions) => Promise<void>;
+  waitFor: <T>(callback: () => T | Promise<T>, options?: WaitForOptions) => Promise<T>;
   /**
    * Asserts something about the element.
    * @param el The element to assert on

--- a/src/utils/waitFor.ts
+++ b/src/utils/waitFor.ts
@@ -1,28 +1,28 @@
 import type { WaitForOptions } from '../twd-types';
 import { log } from './log';
 
-export const waitFor = (
-  callback: () => void | Promise<void>,
+export const waitFor = <T>(
+  callback: () => T | Promise<T>,
   options?: WaitForOptions,
-): Promise<void> => {
+): Promise<T> => {
   const timeout = options?.timeout ?? 2000;
   const interval = options?.interval ?? 50;
   const message = options?.message;
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<T>((resolve, reject) => {
     const start = Date.now();
     let settled = false;
 
     const attempt = async () => {
       try {
-        await callback();
+        const result = await callback();
         if (settled) return;
         settled = true;
         const logMsg = message
           ? `waitFor: resolved (${message})`
           : 'waitFor: resolved';
         log(logMsg);
-        resolve();
+        resolve(result);
       } catch (err) {
         if (settled) return;
         const lastError = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
## Summary

- Make `twd.waitFor()` generic (`<T>`) so it returns the callback's return value instead of `void`
- Fully backwards compatible — existing `void` callbacks still work identically
- Update API docs and AI guides with new signature, examples, and "only use when retry logic is necessary" warning

## Usage

```ts
// Before: all assertions must go inside the callback
await twd.waitFor(() => {
  const event = findEvent("purchase");
  expect(event).to.exist;
  expect(event.customer_type).to.equal("b2c");
});

// After: extract the value and assert outside
const event = await twd.waitFor(() => {
  const ev = findEvent("purchase");
  expect(ev).to.exist;
  return ev;
});
expect(event.customer_type).to.equal("b2c");
```

## Test plan

- [x] 3 new unit tests (sync return, async return, return after retries)
- [x] All 379 existing tests pass
- [x] TypeScript compiles clean in example app (`tsc --noEmit`)
- [x] Build succeeds
- [x] VitePress docs build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)