### PR TITLE
fix(mockBridge): forward responseHeaders to __twdCollectMock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## <small>1.7.2 (2026-04-20)</small>
+
+* fix(mockBridge): forward `responseHeaders` to `__twdCollectMock` so downstream contract validation can apply Content-Type-aware schema selection.
+
+
 ## <small>1.7.1 (2026-04-15)</small>
 
 * feat(waitFor): make generic to return callback value (#214) ([836695c](https://github.com/BRIKEV/twd/commit/836695c14b7563a1e0c83b61f6ccec13145bf69f)), closes [#214](https://github.com/BRIKEV/twd/issues/214)

--- a/src/commands/mockBridge.ts
+++ b/src/commands/mockBridge.ts
@@ -149,6 +149,7 @@ export const mockRequest = async (alias: string, options: Options) => {
         method: options.method,
         status: options.status || 200,
         response: options.response,
+        responseHeaders: options.responseHeaders,
         urlRegex: options.urlRegex || false,
         testId: running.id,
       });

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,6 +12,7 @@ declare global {
       method: string;
       status: number;
       response: unknown;
+      responseHeaders?: Record<string, string>;
       urlRegex: boolean;
       testId: string;
     }) => void;

--- a/src/tests/commands/mockBridge/mockRequest.spec.ts
+++ b/src/tests/commands/mockBridge/mockRequest.spec.ts
@@ -145,6 +145,7 @@ describe('mockBridge mock request methods', () => {
       method: 'POST',
       status: 201,
       response: { id: 1 },
+      responseHeaders: undefined,
       urlRegex: false,
       testId: testId,
     });
@@ -187,7 +188,51 @@ describe('mockBridge mock request methods', () => {
       method: 'GET',
       status: 200,
       response: [],
+      responseHeaders: undefined,
       urlRegex: true,
+      testId: testId,
+    });
+
+    delete window.__twdCollectMock;
+    delete window.__TWD_STATE__;
+  });
+
+  it('should call __twdCollectMock with responseHeaders when provided', async () => {
+    const collectMock = vi.fn();
+    window.__twdCollectMock = collectMock;
+
+    const testId = 'test-headers789';
+    window.__TWD_STATE__ = {
+      handlers: new Map([
+        [testId, { id: testId, name: 'headers test', type: 'test', status: 'running', logs: [], depth: 1 }],
+      ]),
+      beforeEachHooks: new Map(),
+      afterEachHooks: new Map(),
+      stack: [],
+    };
+
+    const postMessageMock = vi.fn();
+    Object.defineProperty(navigator.serviceWorker, 'controller', {
+      configurable: true,
+      get: () => ({ postMessage: postMessageMock }),
+    });
+
+    await mockRequest('qrCode', {
+      url: '/v1/esims/123/qr_code',
+      method: 'GET',
+      status: 200,
+      response: 'fake-qr-data',
+      responseHeaders: { 'Content-Type': 'image/png' },
+    });
+
+    expect(collectMock).toHaveBeenCalledWith({
+      alias: 'qrCode',
+      url: '/v1/esims/123/qr_code',
+      method: 'GET',
+      status: 200,
+      response: 'fake-qr-data',
+      responseHeaders: { 'Content-Type': 'image/png' },
+      urlRegex: false,
       testId: testId,
     });
 


### PR DESCRIPTION
## Summary

- Forward `responseHeaders` from `mockRequest()` options into the `window.__twdCollectMock(...)` payload so downstream contract validation (twd-cli / openapi-mock-validator) can select the right schema by `Content-Type` — eliminating false-positive `MISSING_SCHEMA` warnings for non-JSON mocks (images, PDFs, binary).
- Extend the `Window.__twdCollectMock` global type to accept the new optional field.
- Additive change only: no public API changes, existing `Options`/`Rule` types already declared `responseHeaders`. Backwards compatible — older `twd-cli` versions tolerate extra fields on collected mocks.

## Test plan

- [x] `npm run test:ci` — 380/380 passing
- [x] `npx vitest run src/tests/commands/mockBridge/mockRequest.spec.ts` — 6/6 passing, including new `should call __twdCollectMock with responseHeaders when provided`
- [x] `npm run build` — succeeds
- [ ] Downstream: verify with a real test that mocks a non-JSON endpoint (e.g. `responseHeaders: { 'Content-Type': 'image/png' }`) once `twd-cli` ships its Content-Type-aware validator

## Rollout note

This is step 3 of 3 in the Content-Type validation chain. Safe to ship ahead of `twd-cli` / `openapi-mock-validator` updates — the new field is purely additive and consumers ignore unknown keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)