### PR TITLE
fix(screenDom): prioritize known app roots and skip empty containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## <small>1.7.2 (2026-04-20)</small>
 
 * fix(mockBridge): forward `responseHeaders` to `__twdCollectMock` so downstream contract validation can apply Content-Type-aware schema selection.
+* fix(screenDom): prioritize known app roots (`#root`, `#app`, `app-root`) and skip empty containers when scoping queries; add `rootSelector` option to `initTWD` for non-standard roots (e.g. sandbox environments that inject overlay siblings).
 
 
 ## <small>1.7.1 (2026-04-15)</small>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,8 @@ if (import.meta.env.DEV) {
     position: 'left',
     search: true,                   // Enable search/filter in the sidebar (default: false)
     serviceWorker: true,            // Enable request mocking (default: true)
-    serviceWorkerUrl: '/mock-sw.js' // Custom service worker path (default: '/mock-sw.js')
+    serviceWorkerUrl: '/mock-sw.js',// Custom service worker path (default: '/mock-sw.js')
+    // rootSelector: '#my-app',     // (Optional) Override the app root for screenDom queries
   });
 }
 

--- a/docs/testing-library.md
+++ b/docs/testing-library.md
@@ -42,67 +42,41 @@ import { screenDom, screenDomGlobal } from "twd-js";
 
 ### How screenDom Works
 
-`screenDom` automatically finds your app's root container by searching for the **first direct child of `<body>`** that is not excluded. This works for common patterns like:
-- `<div id="root"></div>`
-- `<app-root></app-root>`
-- `<main></main>`
-- Any other container element
+`screenDom` resolves the app's root container in this priority order:
 
-**Excluded elements:** The following tags are automatically excluded from container selection (as they're not app content):
-- `script` - JavaScript files
-- `style` - CSS stylesheets
-- `svg` - SVG graphics
-- `path` - SVG path elements
-- `noscript` - Fallback content (e.g., Google Tag Manager)
-- `link` - Stylesheet links, favicons
-- `iframe` - Embedded content, analytics widgets
-- `template` - Web component templates
-- `meta` - Metadata tags
+1. **Configured selector** — if you pass `rootSelector` to `initTWD` (e.g. `initTWD(tests, { rootSelector: '#my-app' })`), that selector is tried first.
+2. **Known framework roots** — `#root` (Vite / CRA / Solid), `#app` (Vue), then `app-root` (Angular). Most apps fall into this bucket and need no configuration.
+3. **Heuristic fallback** — the first direct child of `<body>` that isn't the TWD sidebar, isn't an excluded tag, and isn't empty.
+4. **Last resort** — `document.body`.
+
+If resolution reaches step 3 or 4 without a configured `rootSelector`, `screenDom` logs a one-time console warning pointing you to the `rootSelector` option.
+
+**Excluded elements:** The following tags are ignored during the heuristic fallback (they're never app content):
+
+- `script`, `style`, `svg`, `path`, `noscript`, `link`, `iframe`, `template`, `meta`
+
+### Configuring a custom root
+
+If your app mounts into a non-standard element, pass `rootSelector` to `initTWD`:
+
+```ts
+initTWD(tests, {
+  rootSelector: '#my-app',
+});
+```
+
+This is the simplest way to handle apps whose root isn't `#root`, `#app`, or `app-root`.
 
 ### Troubleshooting: When screenDom Can't Find Your Container
 
-If `screenDom` queries fail or return unexpected results, it might be because:
+If `screenDom` queries fail unexpectedly:
 
-1. **Your app root is not the first non-excluded element in `<body>`**
-   
-   ```html
-   <!-- ❌ Problem: Analytics container comes before #root -->
-   <body>
-     <div id="analytics-container"></div>
-     <div id="root"></div>
-   </body>
-   ```
-   
-   **Solution:** Use `screenDomGlobal` instead, or ensure your app root is the first element:
-   
-   ```html
-   <!-- ✅ Good: #root is first -->
-   <body>
-     <div id="root"></div>
-     <div id="analytics-container"></div>
-   </body>
-   ```
-
-2. **You have other elements before your app root**
-   
-   ```html
-   <!-- ❌ Problem: Header or other wrapper before #root -->
-   <body>
-     <header>Site Header</header>
-     <div id="root"></div>
-   </body>
-   ```
-   
-   **Solution:** Use `screenDomGlobal` for queries, or move your app root to be first.
-
-3. **Your app uses a non-standard structure**
-   
-   If your app doesn't follow the standard pattern, `screenDom` will fall back to searching `document.body` (which includes the sidebar). In this case, use `screenDomGlobal` and make your queries more specific to avoid matching sidebar elements.
+1. **Your app uses a non-standard root selector.** Pass it via `initTWD({ rootSelector: '#your-root' })`.
+2. **Your app root exists but hasn't mounted yet.** `screenDom` queries inside a `twd.visit()` flow should run after the route mounts — make sure you `await twd.visit(...)` before querying.
+3. **You need portal-rendered elements (modals, tooltips).** Use `screenDomGlobal` for those; `screenDom` only searches inside the resolved root container.
 
 **When to use `screenDomGlobal` instead:**
-- Your app root is not the first element in `<body>`
 - You need to query portal-rendered elements (modals, dialogs)
-- Your HTML structure doesn't match the expected pattern
 
 ⚠️ **Remember:** When using `screenDomGlobal`, make your queries specific (e.g., `getByRole('button', { name: 'Submit' })`) to avoid accidentally matching elements in the TWD sidebar.
 

--- a/src/bundled.tsx
+++ b/src/bundled.tsx
@@ -2,6 +2,7 @@ import { render } from 'preact';
 import { initTests } from './initializers/initTests';
 import { TWDSidebar } from './ui/TWDSidebar';
 import { initRequestMocking } from './commands/mockBridge';
+import { setRootSelector } from './proxies/screenDom';
 import type { TWDTheme } from './ui/utils/theme';
 
 interface TestModule {
@@ -15,6 +16,7 @@ interface InitTWDOptions {
   serviceWorkerUrl?: string;
   theme?: Partial<TWDTheme>;
   search?: boolean;
+  rootSelector?: string;
 }
 
 // Create a compatibility wrapper for Preact's render to match React's createRoot API
@@ -42,9 +44,14 @@ const createRoot = (el: HTMLElement) => ({
  * initTWD(testModules, { open: true, position: 'left', serviceWorker: true, serviceWorkerUrl: '/mock-sw.js' });
  * @example
  * initTWD(testModules, { open: true, position: 'left', theme: { primary: '#ff0000', background: '#ffffff' } });
+ * @example
+ * initTWD(testModules, { rootSelector: '#my-app' });
  */
 export const initTWD = (files: TestModule, options?: InitTWDOptions) => {
-  const { open = true, position = "left", serviceWorker = true, serviceWorkerUrl = '/mock-sw.js', theme, search } = options || {};
+  const { open = true, position = "left", serviceWorker = true, serviceWorkerUrl = '/mock-sw.js', theme, search, rootSelector } = options || {};
+  if (rootSelector) {
+    setRootSelector(rootSelector);
+  }
   initTests(files, <TWDSidebar open={open} position={position} {...(search !== undefined && { search })} />, createRoot, theme);
   if (serviceWorker) {
   initRequestMocking(serviceWorkerUrl)

--- a/src/proxies/screenDom.ts
+++ b/src/proxies/screenDom.ts
@@ -4,11 +4,67 @@ import { domMessage } from './domMessage';
 
 type ScreenDom = typeof screen;
 
+// Known app-root selectors in priority order (framework semantic signals)
+const ROOT_SELECTOR_PRIORITY = ['#root', '#app', 'app-root'] as const;
+
+const EXCLUDED_FALLBACK_SELECTOR =
+  "body > :not(#twd-sidebar-root):not(script):not(style):not(svg):not(path):not(noscript):not(link):not(meta):not(iframe):not(template)";
+
+const FALLBACK_WARNING =
+  '[TWD] screenDom could not find a known app root (#root / #app / app-root). ' +
+  'Falling back to best-guess container — if queries behave unexpectedly, pass ' +
+  "rootSelector to initTWD: initTWD(modules, { rootSelector: '#my-app' }).";
+
+const state = {
+  rootSelector: null as string | null,
+  warnedOnFallback: false,
+};
+
+/**
+ * Set the app root selector used by screenDom queries. Package-internal —
+ * wired through `initTWD({ rootSelector })`. Not re-exported from `src/index.ts`.
+ */
+export const setRootSelector = (selector: string) => {
+  state.rootSelector = selector;
+};
+
+/**
+ * Reset screenDom module state. Only use in tests.
+ * @internal
+ */
+export const resetScreenDomState = () => {
+  state.rootSelector = null;
+  state.warnedOnFallback = false;
+};
+
+const isNonEmpty = (el: Element): boolean =>
+  el.childElementCount > 0 || (el.textContent?.trim().length ?? 0) > 0;
+
+const warnOnFallbackOnce = () => {
+  if (state.warnedOnFallback) return;
+  state.warnedOnFallback = true;
+  console.warn(FALLBACK_WARNING);
+};
+
 // Define which container to use (anything except the sidebar)
-const getFilteredContainer = () => {
-  // Generic strategy: Find the first direct child of body that isn't the TWD sidebar
-  // This works for <div id="root">, <app-root>, <main>, etc.
-  return document.querySelector("body > :not(#twd-sidebar-root):not(script):not(style):not(svg):not(path):not(noscript):not(link):not(meta):not(iframe):not(template)") ?? document.body;
+const getFilteredContainer = (): HTMLElement => {
+  // 1. User-configured selector (if it matches)
+  if (state.rootSelector) {
+    const configured = document.querySelector(state.rootSelector);
+    if (configured) return configured as HTMLElement;
+  }
+  // 2. Priority list: trust semantic app-root selectors
+  for (const selector of ROOT_SELECTOR_PRIORITY) {
+    const match = document.querySelector(selector);
+    if (match) return match as HTMLElement;
+  }
+  // 3. Fallback heuristic: first non-empty direct body child
+  warnOnFallbackOnce();
+  const candidates = document.querySelectorAll(EXCLUDED_FALLBACK_SELECTOR);
+  for (const candidate of Array.from(candidates)) {
+    if (isNonEmpty(candidate)) return candidate as HTMLElement;
+  }
+  return document.body;
 };
 
 // It takes whatever RTL query the user calls (like getByText) and calls the same function from within(filteredContainer), so the search happens only inside the allowed part of the DOM.

--- a/src/tests/bundled/bundled.spec.ts
+++ b/src/tests/bundled/bundled.spec.ts
@@ -18,8 +18,13 @@ vi.mock('../../commands/mockBridge', () => ({
   initRequestMocking: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../../proxies/screenDom', () => ({
+  setRootSelector: vi.fn(),
+}));
+
 import { initTests } from '../../initializers/initTests';
 import { initRequestMocking } from '../../commands/mockBridge';
+import { setRootSelector } from '../../proxies/screenDom';
 
 describe('initTWD', () => {
   const mockInitRequestMocking = vi.mocked(initRequestMocking);
@@ -101,6 +106,20 @@ describe('initTWD', () => {
     expect(initTests).toHaveBeenCalled();
     const callArgs = (initTests as any).mock.calls[0];
     expect(callArgs[1].props).toEqual({ open: true, position: 'left', search: true });
+  });
+
+  it('should call setRootSelector when rootSelector option is provided', () => {
+    const files = {};
+    initTWD(files, { rootSelector: '#my-app' });
+
+    expect(setRootSelector).toHaveBeenCalledWith('#my-app');
+  });
+
+  it('should not call setRootSelector when rootSelector option is omitted', () => {
+    const files = {};
+    initTWD(files);
+
+    expect(setRootSelector).not.toHaveBeenCalled();
   });
 });
 

--- a/src/tests/proxies/screenDom.spec.ts
+++ b/src/tests/proxies/screenDom.spec.ts
@@ -1,12 +1,13 @@
 import { describe, it, beforeEach, vi, expect } from 'vitest';
 import * as twd from '../../runner';
-import { screenDom, screenDomGlobal } from '../../proxies/screenDom';
+import { screenDom, screenDomGlobal, setRootSelector, resetScreenDomState } from '../../proxies/screenDom';
 
 describe('screenDom', () => {
   beforeEach(() => {
     twd.clearTests();
     vi.clearAllMocks();
     document.body.innerHTML = '';
+    resetScreenDomState();
   });
 
   it('should not select buton in sidebar', () => {
@@ -23,6 +24,145 @@ describe('screenDom', () => {
     button.textContent = 'Click me';
     document.body.appendChild(button);
     expect(screenDom.getByText('Click me')).toBeInTheDocument();
+  });
+
+  it('should prefer #root over other body children regardless of order', () => {
+    const decoy = document.createElement('div');
+    decoy.id = 'highlighter';
+    const decoyButton = document.createElement('button');
+    decoyButton.textContent = 'Click me';
+    decoy.appendChild(decoyButton);
+    document.body.appendChild(decoy);
+
+    const root = document.createElement('div');
+    root.id = 'root';
+    const rootButton = document.createElement('button');
+    rootButton.textContent = 'Submit';
+    root.appendChild(rootButton);
+    document.body.appendChild(root);
+
+    expect(screenDom.getByText('Submit')).toBeInTheDocument();
+    expect(screenDom.queryByText('Click me')).toBeNull();
+  });
+
+  it('should prefer #app when #root is absent', () => {
+    const app = document.createElement('div');
+    app.id = 'app';
+    const appButton = document.createElement('button');
+    appButton.textContent = 'Vue button';
+    app.appendChild(appButton);
+    document.body.appendChild(app);
+
+    expect(screenDom.getByText('Vue button')).toBeInTheDocument();
+  });
+
+  it('should prefer app-root when #root and #app are absent', () => {
+    const ng = document.createElement('app-root');
+    const ngButton = document.createElement('button');
+    ngButton.textContent = 'Angular button';
+    ng.appendChild(ngButton);
+    document.body.appendChild(ng);
+
+    expect(screenDom.getByText('Angular button')).toBeInTheDocument();
+  });
+
+  it('should skip empty body children in the heuristic fallback', () => {
+    // No #root / #app / app-root — must fall back to the heuristic
+    const empty = document.createElement('div');
+    empty.id = 'highlighter';
+    document.body.appendChild(empty);
+
+    const custom = document.createElement('div');
+    custom.id = 'custom-app';
+    const customText = document.createElement('span');
+    customText.textContent = 'Hello custom';
+    custom.appendChild(customText);
+    document.body.appendChild(custom);
+
+    expect(screenDom.getByText('Hello custom')).toBeInTheDocument();
+  });
+
+  it('should use configured rootSelector when provided', () => {
+    const custom = document.createElement('div');
+    custom.id = 'my-app';
+    const customText = document.createElement('span');
+    customText.textContent = 'Custom app content';
+    custom.appendChild(customText);
+    document.body.appendChild(custom);
+
+    const root = document.createElement('div');
+    root.id = 'root';
+    const rootText = document.createElement('span');
+    rootText.textContent = 'Default root content';
+    root.appendChild(rootText);
+    document.body.appendChild(root);
+
+    setRootSelector('#my-app');
+
+    expect(screenDom.getByText('Custom app content')).toBeInTheDocument();
+    expect(screenDom.queryByText('Default root content')).toBeNull();
+  });
+
+  it('should warn exactly once when falling back to the heuristic', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // No #root / #app / app-root — heuristic will fire
+    const custom = document.createElement('div');
+    custom.id = 'custom-app';
+    custom.textContent = 'Hello';
+    document.body.appendChild(custom);
+
+    screenDom.getByText('Hello');
+    screenDom.getByText('Hello');
+    screenDom.getByText('Hello');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('[TWD]');
+    expect(warnSpy.mock.calls[0][0]).toContain('rootSelector');
+
+    warnSpy.mockRestore();
+  });
+
+  it('should not warn when a configured rootSelector matches', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const custom = document.createElement('div');
+    custom.id = 'my-app';
+    custom.textContent = 'Hello';
+    document.body.appendChild(custom);
+
+    setRootSelector('#my-app');
+    screenDom.getByText('Hello');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should fall through to priority list without warning when configured rootSelector does not match but priority list matches', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const root = document.createElement('div');
+    root.id = 'root';
+    root.textContent = 'Priority hit';
+    document.body.appendChild(root);
+
+    setRootSelector('#does-not-exist');
+
+    // #root is matched via priority list — no warn because priority list succeeded
+    expect(screenDom.getByText('Priority hit')).toBeInTheDocument();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should warn when configured selector misses AND priority list misses', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const custom = document.createElement('div');
+    custom.id = 'custom-app';
+    custom.textContent = 'Heuristic hit';
+    document.body.appendChild(custom);
+
+    setRootSelector('#does-not-exist');
+
+    expect(screenDom.getByText('Heuristic hit')).toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
   });
 
   it('should throw an error if we have two buttons one in sidebar and one in the body using global screen selector', () => {


### PR DESCRIPTION
## Summary

- Make `screenDom` query scoping robust against injected body siblings (sandbox overlays, browser extensions) that currently silently hijack queries by landing before the app root in DOM order.
- Resolve the container in priority order: user-configured `rootSelector` → `#root` / `#app` / `app-root` → first non-empty direct body child → `document.body`.
- Add `rootSelector?: string` option on `InitTWDOptions`, wired through `initTWD` to a package-internal setter (no new public exports from `twd-js`).
- Emit a one-time-per-session `console.warn` when the heuristic fallback fires without a configured `rootSelector`, pointing users to the new option.

## Motivation

Reproduced on CodeSandbox Devbox: CodeSandbox injects `<div id=\"highlighter\">` before `<div id=\"root\">` for its click-to-inspect overlay, and every `screenDom.getByText(...)` silently fails with \"element not found\" because the (empty) highlighter became the scoped container. Any browser extension or framework overlay that injects a body sibling has the same effect. First-install experience on a sandbox is a silent breakage.

## What changes

- `src/proxies/screenDom.ts` — priority list + skip-empty heuristic + one-time warn + module-state reset for tests.
- `src/bundled.tsx` — `rootSelector?: string` on `InitTWDOptions`; `initTWD` forwards to the internal setter before `initTests` / `initRequestMocking`.
- Docs: `docs/testing-library.md` (rewritten \"How screenDom Works\" + troubleshooting); `docs/getting-started.md` (new commented option in the `initTWD` example).
- CHANGELOG: additional bullet under the existing unreleased `1.7.2` entry — no version bump.

## Non-goals

- No public re-export of `setRootSelector` or `resetScreenDomState` — those are package-internal.
- No signature change to `initTests` (React-path power users who need a custom root use `initTWD`).
- No change to `screenDomGlobal`.

## Test plan

- [x] `npm run test:ci` — 391/391 passing across 54 files
- [x] `npm run docs:build` — VitePress build clean
- [x] `npm run build` — succeeds; the TS errors in `src/plugin/*` are pre-existing and unrelated
- [x] New unit tests cover: priority order (`#root` > decoy, `#app` fallback, `app-root` fallback), skip-empty heuristic, configured selector wins, configured-but-missing falls through, warn fires exactly once per session
- [ ] Manual verification on CodeSandbox (run an example app and confirm the `#highlighter` regression no longer manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)