### PR TITLE
docs: use absolute GitHub URLs for README images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code Coverage](https://qlty.sh/gh/BRIKEV/projects/twd/coverage.svg)](https://qlty.sh/gh/BRIKEV/projects/twd)
 
 <p align="center">
-  <img src="./images/twd-skill.gif" alt="TWD running with an AI agent" width="800">
+  <img src="https://raw.githubusercontent.com/BRIKEV/twd/main/images/twd-skill.gif" alt="TWD running with an AI agent" width="800">
 </p>
 
 TWD is a library designed to seamlessly integrate testing into your web development workflow. It streamlines the process of writing, running, and managing tests directly in your application, with a modern UI and powerful mocking capabilities.
@@ -101,7 +101,7 @@ describe("Hello World Page", () => {
 3. **Run your app** - The TWD sidebar will appear automatically in development mode!
 
 <p align="center">
-  <img src="./images/twd_side_bar_success.png" alt="TWD Sidebar in action" width="800">
+  <img src="https://raw.githubusercontent.com/BRIKEV/twd/main/images/twd_side_bar_success.png" alt="TWD Sidebar in action" width="800">
 </p>
 
 ## Key Concepts
@@ -155,7 +155,7 @@ Full documentation is available at [twd.dev](https://twd.dev) (coming soon) or i
 
 Check out our working examples for various frameworks:
 
-- **[Examples Directory](./examples)** - Local examples for React, Vue, and Astro
+- **[Examples Directory](https://github.com/BRIKEV/twd/tree/main/examples)** - Local examples for React, Vue, and Astro
 - **[Vue Example](https://github.com/BRIKEV/twd-vue-example)** - Vue 3 with advanced scenarios
 - **[Solid Example](https://github.com/BRIKEV/twd-solid-example)** - Solid.js integration
 - **[Angular Example](https://github.com/BRIKEV/twd-angular-example)** - Angular setup


### PR DESCRIPTION
## Summary

Replaces relative paths in README.md with absolute URLs so they render reliably across github.com, npmjs.com, and any other markdown viewer that doesn't auto-rewrite relative paths.

## Changes

| Before | After |
|---|---|
| `./images/twd-skill.gif` | `https://raw.githubusercontent.com/BRIKEV/twd/main/images/twd-skill.gif` |
| `./images/twd_side_bar_success.png` | `https://raw.githubusercontent.com/BRIKEV/twd/main/images/twd_side_bar_success.png` |
| `[Examples Directory](./examples)` | `[Examples Directory](https://github.com/BRIKEV/twd/tree/main/examples)` |

## Why

The `images/` folder is not in the npm tarball (`"files": ["dist", "README.md", "LICENSE"]` excludes it). The previous relative paths only rendered correctly when npmjs.com auto-rewrote them via the `repository` field — which works most of the time but had a propagation delay around the 1.7.3 release that briefly showed broken images. Absolute URLs eliminate that dependency.

The contributor avatars in this README already use absolute URLs to `avatars.githubusercontent.com` — this brings the GIF and screenshot in line with that pattern.

## Test plan

- [x] No code changes; README-only
- [ ] Visual verification on the PR's "Files changed" tab — images render
- [ ] Will be folded into the next release (no urgent republish; 1.7.3 already renders fine via npm's auto-rewrite once propagation completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)