### PR TITLE
fix(a11y): address audit findings on docs site + sidebar

### DIFF
--- a/docs/.vitepress/theme/components/AdoptionLineDiagram.vue
+++ b/docs/.vitepress/theme/components/AdoptionLineDiagram.vue
@@ -56,7 +56,7 @@ const stages = [
         >
           <span v-if="stage.badge" class="adopt-badge" :class="`adopt-badge--${stage.state}`">{{ stage.badge }}</span>
           <span class="adopt-eyebrow">{{ stage.eyebrow }}</span>
-          <span class="adopt-pkg">{{ stage.package }}</span>
+          <h3 class="adopt-pkg">{{ stage.package }}</h3>
           <span class="adopt-desc">{{ stage.description }}</span>
           <span v-if="stage.cta" class="adopt-cta">
             {{ stage.cta }}<span class="adopt-cta__sr"> about {{ stage.package }}</span><span aria-hidden="true"> →</span>
@@ -154,8 +154,12 @@ a.adopt-stage:focus-visible {
 }
 
 .adopt-pkg {
+  /* h3 for heading-navigation reach (incl. the non-link "Ship" card); reset
+     default heading margins so the card layout is visually unchanged */
+  margin: 0;
   font-size: 1.0625rem;
   font-weight: 700;
+  line-height: 1.3;
   color: var(--vp-c-text-1);
 }
 

--- a/docs/.vitepress/theme/components/AdoptionLineDiagram.vue
+++ b/docs/.vitepress/theme/components/AdoptionLineDiagram.vue
@@ -2,17 +2,17 @@
 const stages = [
   {
     state: 'start',
-    eyebrow: 'SIDEBAR',
+    eyebrow: 'Sidebar',
     package: 'twd-js',
     description: 'Sidebar in your browser. Tests live where you build.',
-    badge: 'START HERE',
+    badge: 'Start here',
     cta: 'Learn more',
     href: '/twd-js',
     umamiEvent: 'home_ecosystem_sidebar',
   },
   {
     state: 'optional',
-    eyebrow: 'AI AGENT',
+    eyebrow: 'AI agent',
     package: 'twd-relay + twd-ai',
     description: 'Add when you use AI coding agents.',
     badge: '',
@@ -22,7 +22,7 @@ const stages = [
   },
   {
     state: 'optional',
-    eyebrow: 'CONTRACT TESTING',
+    eyebrow: 'Contract testing',
     package: 'twd-cli',
     description: 'Add when you want CI, coverage, and contract validation.',
     badge: '',
@@ -32,7 +32,7 @@ const stages = [
   },
   {
     state: 'ship',
-    eyebrow: 'SHIP',
+    eyebrow: 'Ship',
     package: 'Merge with confidence',
     description: 'Contracts validated, tests green.',
     badge: '',
@@ -144,7 +144,7 @@ a.adopt-stage:focus-visible {
 .adopt-eyebrow {
   font-size: 0.6875rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.02em;
   color: var(--vp-c-brand-1);
   margin-top: 4px;
 }

--- a/docs/.vitepress/theme/components/AdoptionLineDiagram.vue
+++ b/docs/.vitepress/theme/components/AdoptionLineDiagram.vue
@@ -117,7 +117,6 @@ a.adopt-stage:hover,
 a.adopt-stage:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 6px 16px -8px rgba(0, 0, 0, 0.25);
-  outline: none;
 }
 
 .adopt-stage--start:hover,

--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -251,10 +251,9 @@ const faqs = [
       <!-- Section 6: Manifesto Quote -->
       <section class="manifesto-quote">
         <blockquote class="manifesto-text">
-          <span class="manifesto-mark" aria-hidden="true">&ldquo;</span>
           TWD isn't about writing <em>more</em> tests — it's about writing the <em>right</em> ones, at the right time.
         </blockquote>
-        <a href="/twd-manifesto" class="manifesto-link">Read the full manifesto &rarr;</a>
+        <a href="/twd-manifesto" class="manifesto-link">Read the full manifesto<span class="visually-hidden"> on testing philosophy</span><span aria-hidden="true"> &rarr;</span></a>
       </section>
 
       <!-- Section 7: Final CTA -->
@@ -661,7 +660,8 @@ const faqs = [
 .code-filename {
   margin-left: 8px;
   font-size: 0.6875rem;
-  color: var(--vp-c-text-3);
+  /* text-2 (not text-3) to clear AA contrast in both themes (WCAG 1.4.3) */
+  color: var(--vp-c-text-2);
   font-family: var(--vp-font-family-mono);
   letter-spacing: 0.02em;
 }
@@ -813,21 +813,6 @@ details[open] .faq-question::before {
   border: none;
   padding: 0;
   letter-spacing: -0.01em;
-  position: relative;
-}
-
-.manifesto-mark {
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 8rem;
-  line-height: 0;
-  color: var(--vp-c-brand-1);
-  opacity: 0.15;
-  position: absolute;
-  top: -20px;
-  left: 50%;
-  transform: translateX(-50%);
-  pointer-events: none;
-  user-select: none;
 }
 
 .manifesto-text em {
@@ -840,7 +825,9 @@ details[open] .faq-question::before {
   margin-top: 24px;
   font-size: 0.9375rem;
   color: var(--vp-c-brand-1);
-  text-decoration: none;
+  /* Underline so the link isn't distinguished by color alone (WCAG 1.4.1) */
+  text-decoration: underline;
+  text-underline-offset: 3px;
   font-weight: 600;
   transition: opacity 0.2s;
 }

--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -401,8 +401,7 @@ const faqs = [
   display: inline-block;
   font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--vp-c-brand-1);
   margin-bottom: 20px;
   padding: 6px 16px;

--- a/docs/.vitepress/theme/components/LandingCrossLinks.vue
+++ b/docs/.vitepress/theme/components/LandingCrossLinks.vue
@@ -65,18 +65,21 @@ defineProps({
 .landing-xlinks__link:focus-visible {
   border-color: var(--vp-c-brand-1);
   transform: translateY(-1px);
-  outline: none;
 }
 
 .landing-xlinks__title {
   font-size: 0.9375rem;
   font-weight: 700;
   color: var(--vp-c-text-1);
+  /* Underline the link affordance so it isn't distinguished by color alone (WCAG 1.4.1) */
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .landing-xlinks__blurb {
   font-size: 0.8125rem;
   line-height: 1.55;
-  color: var(--vp-c-text-3);
+  /* text-2 (not text-3) to clear AA contrast on bg-soft in both themes (WCAG 1.4.3) */
+  color: var(--vp-c-text-2);
 }
 </style>

--- a/docs/.vitepress/theme/components/LandingHero.vue
+++ b/docs/.vitepress/theme/components/LandingHero.vue
@@ -42,8 +42,7 @@ defineProps({
   display: inline-block;
   font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
   color: var(--vp-c-brand-1);
   padding: 4px 14px;
   border: 1px solid var(--vp-c-brand-soft);

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -33,6 +33,38 @@
   --vp-home-hero-name-color: var(--vp-c-brand-1);
 }
 
+/* ============================================
+   Accessibility (a11y audit, June 2026)
+   ============================================ */
+
+/* Focus ring: visible 2px indicator with a 2px gap, in both themes.
+   --vp-c-text-1 is theme-scoped (near-black light / near-white dark) so the
+   ring always clears 3:1 against the page background (WCAG 2.4.11 / 1.4.11). */
+:focus-visible {
+  outline: 2px solid var(--vp-c-text-1);
+  outline-offset: 2px;
+}
+
+/* Focusable elements inside an overflow:hidden container (FAQ accordion summary,
+   code blocks) have their offset ring clipped — inset it so it stays visible. */
+.faq-question:focus-visible,
+.code-block pre:focus-visible,
+.vp-doc [class*='language-'] pre:focus-visible,
+.outline-link:focus-visible {
+  outline-offset: -2px;
+}
+
+/* Code-block contrast (WCAG 1.4.3). The github shiki themes hardcode the comment
+   token to #6A737D for BOTH light and dark (4.45 light / 3.75 dark — both fail AA).
+   Split it: darker on light, lighter on dark. Mirrors VitePress's own
+   light/dark token-color pattern. */
+html:not(.dark) .vp-doc span[style*="--shiki-light:#6A737D" i] {
+  color: #57606a !important;
+}
+.dark .vp-doc span[style*="--shiki-dark:#6A737D" i] {
+  color: #8b949e !important;
+}
+
 /* Pipeline diagram colors */
 :root {
   --pipeline-card-bg: rgba(18, 57, 86, 0.08);

--- a/src/ui/utils/styles.ts
+++ b/src/ui/utils/styles.ts
@@ -154,15 +154,14 @@ export const CSS_STYLES = `
   margin-bottom: var(--twd-spacing-sm);
 }
 .twd-test-group-toggle {
-  font-weight: var(--twd-font-weight-medium);
-  font-size: var(--twd-font-size-sm);
+  font-weight: var(--twd-font-weight-bold);
+  font-size: var(--twd-font-size-md);
   cursor: pointer;
   color: var(--twd-describe-text);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--twd-spacing-sm);
-  text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 .twd-test-item {
@@ -173,7 +172,7 @@ export const CSS_STYLES = `
   border-radius: var(--twd-border-radius);
 }
 .twd-test-item-name {
-  font-weight: var(--twd-font-weight-medium);
+  font-weight: var(--twd-font-weight-normal);
   font-size: var(--twd-font-size-md);
   color: var(--twd-text);
   max-width: 220px;

--- a/src/ui/utils/theme.ts
+++ b/src/ui/utils/theme.ts
@@ -98,7 +98,7 @@ export const defaultTheme: TWDTheme = {
 
   // Describe blocks
   describeBg: '#0f172a',
-  describeText: '#94a3b8',
+  describeText: '#f1f5f9',
   describeBorder: '#334155',
 
   // Status colors


### PR DESCRIPTION
## What

Accessibility fixes for the docs site (twd.dev), addressing findings from the June 2026 WCAG 2.2 A/AA audit. Scope is the **VitePress docs site only** — the twd-js sidebar tool (`src/`) is a separate follow-up.

## Changes

**Focus indicator (2.4.7 / 2.4.11 / 1.4.11)**
- Global `:focus-visible` ring: 2px solid `--vp-c-text-1` with 2px offset (theme-aware, clears 3:1 in both themes).
- Inset variant (`outline-offset: -2px`) for focus targets inside `overflow: hidden` containers — FAQ accordion, custom + markdown code blocks, and the "On this page" outline — so the ring isn't clipped.
- Removed `outline: none` overrides in `LandingCrossLinks` and `AdoptionLineDiagram`.

**Contrast (1.4.3)**
- Split the github shiki comment token `#6A737D` (fails AA in both themes) into `#57606a` light / `#8b949e` dark.
- `.code-filename` and `.landing-xlinks__blurb`: `--vp-c-text-3` → `--vp-c-text-2`.

**Links (1.4.1 / 2.4.4)**
- Underline the manifesto link and cross-link card titles (no longer color-only). Scoped to landing surfaces.
- sr-only context on the manifesto link.

**Cognitive / readability (COGA — 3.1.5 / 1.4.8)**
- Removed sustained uppercase on hero/landing eyebrows and adoption-line eyebrow/badge strings (now sentence case); tightened letter-spacing.

**Screen-reader structure (4.1.2)**
- Adoption-line cards use `<h3>` for the package name, so the non-link "Merge with confidence" end-state card is reachable via heading navigation.

## Not included (intentional)
- Body-content link underlines (kept color + brand only, by decision).
- Search modal cognitive-load (VitePress plugin, not changeable).
- Text-spacing (1.4.12) check — layout is flexible; parked, no failure observed.
- Sidebar tool colors / keyboard nav in `src/` — separate work.

## Verify
Run `npm run docs:dev`, tab through the homepage + a sub-product page (e.g. `/twd-js`) in **both** light and dark themes; confirm a visible focus ring everywhere (inset on accordion/code/outline), readable code comments, underlined landing links, and sentence-case eyebrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: sidebar tool a11y (src/)

Also includes accessibility fixes for the twd-js sidebar test list:
- Removed forced uppercase on describe group headers (render in author's casing).
- Describe headers: bold (700) + brighter default `describeText` (`#94a3b8 → #f1f5f9`) for legibility and AA contrast; test names use normal (400). Hierarchy now carried by weight + box, not uppercase.
- Kept the `--twd-describe-text` token in CSS so the `describeText` theme option still works — only its default changed.