### PR TITLE
docs: add accessibility statement page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -119,6 +119,7 @@ export default defineConfig({
         text: 'Community',
         items: [
           { text: 'Community & Examples', link: '/community' },
+          { text: 'Accessibility Statement', link: '/accessibility-statement' },
         ]
       },
       {

--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -267,7 +267,14 @@ const faqs = [
         </a>
       </section>
 
-      <div style="height: 80px;"></div>
+      <footer class="hp-footer">
+        <nav class="hp-footer-links" aria-label="Footer">
+          <a href="/accessibility-statement" class="hp-footer-link">Accessibility Statement</a>
+          <span class="hp-footer-sep" aria-hidden="true">·</span>
+          <a href="https://github.com/BRIKEV/twd" target="_blank" rel="noopener" class="hp-footer-link">GitHub<span class="visually-hidden"> (opens in new tab)</span></a>
+        </nav>
+        <p class="hp-footer-meta">Released under the MIT License. Copyright © 2025 BRIKEV.</p>
+      </footer>
     </main>
   </div>
 </template>
@@ -927,5 +934,48 @@ details[open] .faq-question::before {
   .manifesto-text {
     font-size: 1.25rem;
   }
+}
+
+/* ============================================
+   Footer
+   ============================================ */
+.hp-footer {
+  margin-top: 4rem;
+  padding: 2rem 1.5rem 3rem;
+  border-top: 1px solid var(--hp-border);
+  text-align: center;
+}
+
+.hp-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.hp-footer-link {
+  color: var(--vp-c-brand-1);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  /* Underline so the link is distinguished by more than colour (WCAG 1.4.1) */
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.hp-footer-link:hover,
+.hp-footer-link:focus-visible {
+  text-decoration-thickness: 2px;
+}
+
+.hp-footer-sep {
+  color: var(--vp-c-text-3);
+}
+
+.hp-footer-meta {
+  color: var(--vp-c-text-2);
+  font-size: 0.875rem;
+  margin: 0;
 }
 </style>

--- a/docs/accessibility-statement.md
+++ b/docs/accessibility-statement.md
@@ -1,0 +1,171 @@
+---
+title: Accessibility Statement
+description: Accessibility statement for TWD. Full conformance with WCAG 2.2 Level AA, EN 301 549, and the European Accessibility Act.
+outline: deep
+---
+
+# Accessibility Statement for TWD
+
+Test While Developing - [twd.dev](https://twd.dev/)
+
+> **Status:** Full conformance with WCAG 2.2 Level AA.
+>
+> Audited June 2026 by Latam11y. Last updated: 21 June 2026.
+
+## 1. Introduction
+
+BRIKEV is committed to digital
+accessibility and inclusion. We want everyone, including people with
+disabilities, to be able to successfully use our website and the TWD testing
+tool.
+
+This statement explains the extent to which TWD complies with the requirements
+of European standard
+[EN 301 549](https://www.etsi.org/deliver/etsi_en/301500_302000/301549/03.02.01_60/en_301549v030201p.pdf)
+(the technical reference of the
+[European Accessibility Act (EAA, EU Directive 2019/882)](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32019L0882))
+and the
+[Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG22/).
+It covers the TWD website ([twd.dev](https://twd.dev/)) and the twd-js tool.
+
+We review this statement periodically as the service evolves.
+
+## 2. Service overview
+
+**TWD ("Test While Developing")** is an **open-source** frontend testing
+framework, published under the MIT licence, that allows development teams to
+write and run tests directly while developing, without needing to switch
+context.
+
+Its main component, **twd-js**, integrates as a browser sidebar in the
+development environment and is compatible with React, Vue, Angular, Solid.js,
+React Router, and other Vite-based frameworks.
+
+The audited service comprises:
+
+- The website [https://twd.dev/](https://twd.dev/): homepage and getting-started
+  documentation.
+- The **twd-js** tool ([npm package twd-js](https://www.npmjs.com/package/twd-js)),
+  audited as an application installed in the development browser.
+
+## 3. How to use TWD (accessibility and operation)
+
+The TWD website has been designed to be navigable and usable with keyboard and
+screen readers. The main accessibility features are described below.
+
+### Keyboard navigation
+
+All links, buttons, and interactive elements are reachable with the
+<kbd>Tab</kbd> key. The focus order is logical and consistent with the visual
+flow of the page. There are no keyboard traps.
+
+### Focus indicator
+
+The focus indicator is visible on all components of the site and the tool, in
+both light and dark themes. It meets a minimum stroke of 2&nbsp;px and a
+2&nbsp;px offset from the content, with sufficient contrast against adjacent
+colours (minimum 3:1).
+
+### Colour contrast
+
+Site text meets a minimum contrast ratio of 4.5:1 for normal text and 3:1 for
+large text, in both light and dark themes. Non-text components of the tool meet
+the minimum 3:1 ratio.
+
+### Link purpose
+
+Links are descriptive and distinguishable by more than colour alone.
+
+### Screen reader compatibility
+
+Tested with NVDA 2026.1 on Windows 11. Interactive components correctly announce
+their name, role, and state.
+
+## 4. Accessibility compliance
+
+We have evaluated TWD (website and twd-js tool) against the accessibility
+requirements of Annex I of the EAA, technically implemented through EN 301 549
+and WCAG 2.2, across the four POUR principles:
+
+| Principle | Summary |
+| --- | --- |
+| **Perceivable** | Content is structured with headings, lists, and ARIA landmarks. Text meets the required contrast ratios in both themes. Information is not conveyed by colour alone. |
+| **Operable** | All functionality is keyboard accessible. Focus indicators are visible and have sufficient contrast. There are no keyboard traps. |
+| **Understandable** | Content is written in plain, consistent English. Navigation and structure are consistent across all pages. |
+| **Robust** | The site is built with semantic HTML5 and correct ARIA roles, compatible with current browser versions and assistive technologies. |
+
+**Reference standards:**
+
+- [WCAG 2.2 Level AA](https://www.w3.org/TR/WCAG22/)
+- [EN 301 549 v3.2.1](https://www.etsi.org/deliver/etsi_en/301500_302000/301549/03.02.01_60/en_301549v030201p.pdf)
+- [EAA, Directive 2019/882/EU](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32019L0882)
+
+::: info Conformance status
+**Full conformance with WCAG 2.2 Level AA.** All evaluated Level A and AA success
+criteria are met.
+:::
+
+**Audit information:**
+
+| | |
+| --- | --- |
+| **Audited by** | María Pía Peña Foissac - Latam11y, digital accessibility consultancy ([mariapiapenafoissac@gmail.com](mailto:mariapiapenafoissac@gmail.com)) |
+| **Date** | June 2026 |
+| **Methodology** | Manual review with keyboard and NVDA 2026.1 on Windows 11 (26H1); colour contrast verification with Tanaguru Contrast Finder |
+| **Scope** | [twd.dev](https://twd.dev/) (Home + Getting Started) plus the twd-js tool (browser sidebar) |
+
+## 5. Ongoing monitoring and maintenance
+
+Accessibility for TWD is an ongoing process. Measures in place include:
+
+- Accessibility review when significant changes are made to the site or tool.
+- Tracking of reported accessibility issues through the
+  [GitHub repository](https://github.com/BRIKEV/twd/issues).
+- Commitment to update this statement following new audits or relevant changes.
+- Monitoring of updates to WCAG and EN 301 549.
+
+## 6. Known limitations
+
+There are no known areas of TWD (website or twd-js tool) that are inaccessible.
+All Level A and AA conformance criteria evaluated have been remediated. This
+statement will be updated if new limitations are identified.
+
+## 7. Disproportionate burden
+
+BRIKEV does not claim any exemption or
+disproportionate burden in meeting the applicable accessibility requirements.
+Should a specific situation require such an assessment in the future, it will be
+documented in accordance with Annex VI of the EAA and this statement will be
+updated.
+
+## 8. Feedback and contact information
+
+If you experience any difficulty accessing any part of TWD, identify an
+accessibility issue, or have suggestions for improvement, please let us know:
+
+- **Email:** [hello.brikev@gmail.com](mailto:hello.brikev@gmail.com?subject=TWD%20Accessibility)
+- **GitHub Issues:** [github.com/BRIKEV/twd/issues](https://github.com/BRIKEV/twd/issues)
+- **GitHub Discussions:** [github.com/BRIKEV/twd/discussions](https://github.com/BRIKEV/twd/discussions)
+
+When contacting us, please provide as much detail as possible: which page or
+component, what happened, and what assistive technology you are using.
+
+**Response time commitments:**
+
+- **5 business days** - acknowledgement.
+- **30 business days** - resolution or update.
+
+## 9. Document history
+
+This accessibility statement was first published on 21 June 2026. It was last
+reviewed and updated on 21 June 2026. We intend to review it at least annually
+or whenever significant changes are made to the service.
+
+---
+
+Statement prepared in accordance with the
+[European Accessibility Act (EU Directive 2019/882)](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32019L0882)
+and standard
+[EN 301 549 v3.2.1](https://www.etsi.org/deliver/etsi_en/301500_302000/301549/03.02.01_60/en_301549v030201p.pdf).
+Audited by María Pía Peña Foissac and Daiana Elizabeth Carbonell,
+[Latam11y](mailto:mariapiapenafoissac@gmail.com), June 2026.

--- a/specs/2026-06-21-accessibility-statement-design.md
+++ b/specs/2026-06-21-accessibility-statement-design.md
@@ -1,0 +1,151 @@
+# Accessibility Statement Page - Design
+
+Date: 2026-06-21
+Branch: `docs/accessibility-statement`
+
+## Context
+
+TWD was audited for accessibility (June 2026, by Latam11y) against WCAG 2.2
+Level AA, EN 301 549, and the European Accessibility Act (EU Directive
+2019/882). The auditors delivered a standalone, self-styled HTML statement
+(`TWD-Accessibility-Statement-EN.html`). We need to publish this statement on
+the TWD documentation site (VitePress, served at twd.dev).
+
+Two problems to solve:
+
+1. **Format.** The delivered HTML is a fully self-styled standalone page. The
+   VitePress default theme is already accessible (keyboard nav, visible focus,
+   dark mode, sufficient contrast) and themed, so we adapt the content to clean
+   markdown rather than port the custom CSS.
+2. **Discoverability.** The site has no visible footer. The home page
+   (`index.md`) uses `layout: false` with a custom `HomePage.vue` that ends in a
+   CTA plus a spacer; doc pages have a sidebar, which suppresses the VitePress
+   `themeConfig.footer`. An accessibility statement conventionally lives in the
+   footer, so a reader currently has nowhere to find it.
+
+## Goals
+
+- Publish the accessibility statement as a maintainable VitePress markdown page.
+- Make it discoverable from both the docs sidebar and the home page.
+- Preserve all substantive content, links, and standards references from the
+  audited statement.
+
+## Non-goals
+
+- Reproducing the auditors' custom visual design (cards, badges, pills) pixel
+  for pixel.
+- Filling in legal placeholders (entity name, dates, escalation authority) -
+  these are marked TODO for the maintainer to complete before public launch.
+
+## Decisions (confirmed with user)
+
+| Topic | Decision |
+|---|---|
+| Placement | Add to existing **Community** sidebar group, plus a footer-style link on the home page. |
+| Format | Clean VitePress markdown using native containers, tables, and links. |
+| Placeholders | Mark as clearly visible TODOs. |
+| Prose style | No em-dashes (per user preference); use hyphens, commas, or parentheses. |
+
+## Changes
+
+### 1. New page: `docs/accessibility-statement.md`
+
+Frontmatter matches the standard content-page pattern:
+
+```yaml
+---
+title: Accessibility Statement
+description: Accessibility statement for TWD. Full conformance with WCAG 2.2 Level AA, EN 301 549, and the European Accessibility Act.
+outline: deep
+---
+```
+
+Sections (mapped 1:1 from the source statement):
+
+1. Introduction - commitment, standards covered (EN 301 549, EAA, WCAG 2.2),
+   scope (twd.dev + twd-js).
+2. Service overview - what TWD and twd-js are, what was audited.
+3. How to use TWD - keyboard navigation, focus indicator, colour contrast, link
+   purpose, screen reader compatibility (each as an `###` subsection).
+4. Accessibility compliance:
+   - POUR principles (Perceivable, Operable, Understandable, Robust) as a short
+     list or simple table.
+   - Reference standards as a bulleted list of external links (WCAG 2.2 AA,
+     EN 301 549 v3.2.1, EAA Directive 2019/882).
+   - Conformance status in a `::: info` (or `::: tip`) container.
+   - Audit details as a markdown table (Audited by, Date, Methodology, Scope).
+5. Ongoing monitoring and maintenance.
+6. Known limitations.
+7. Disproportionate burden - contains a TODO placeholder for the legal entity.
+8. Feedback and contact - email (hello.brikev@gmail.com), GitHub Issues, GitHub
+   Discussions, response-time commitments, escalation block with a TODO for the
+   competent authority.
+9. Document history - first published / last updated, both TODO.
+
+External links preserved from source: W3C WCAG 2.2, ETSI EN 301 549 PDF, EUR-Lex
+EAA directive, npm twd-js, GitHub repo/issues/discussions.
+
+TODO placeholders to surface visibly in the page:
+- Legal entity / name (Introduction, Disproportionate burden).
+- First-published date and last-updated date (Document history, and the meta
+  line near the title).
+- Competent authority for escalation and its info link (Feedback section).
+
+### 2. Sidebar registration: `docs/.vitepress/config.mts`
+
+Append to the existing `Community` group in the `sidebar` array:
+
+```ts
+{
+  text: 'Community',
+  items: [
+    { text: 'Community & Examples', link: '/community' },
+    { text: 'Accessibility Statement', link: '/accessibility-statement' },
+  ],
+},
+```
+
+No `nav` change (top nav stays focused on product/tooling).
+
+### 3. Home page footer link: `docs/.vitepress/theme/components/HomePage.vue`
+
+The template currently ends (around line 270) with:
+
+```html
+      <div style="height: 80px;"></div>
+    </main>
+  </div>
+</template>
+```
+
+Replace the bare spacer with a small, semantic footer landmark containing the
+accessibility link and the license/copyright line. Requirements:
+
+- Use a `<footer>` element (page-level footer landmark).
+- Link text "Accessibility Statement" pointing to `/accessibility-statement`.
+- Include "MIT License" and "Copyright (c) 2025 BRIKEV" to mirror the configured
+  `themeConfig.footer` that never renders on this custom-layout page.
+- Links underlined / distinguishable by more than colour (consistent with the
+  existing `LandingCrossLinks` WCAG 1.4.1 note in this codebase).
+- Style with scoped CSS consistent with the existing component (muted text,
+  centered, top border), respecting light and dark themes via existing CSS
+  variables.
+
+## Verification
+
+1. `cd docs && npm run docs:dev` (or the repo's documented docs dev command).
+2. Visit `/accessibility-statement` - page renders, all sections present, TODO
+   placeholders clearly visible, external links resolve, table and info
+   container render correctly in both light and dark themes.
+3. Confirm "Accessibility Statement" appears in the sidebar under Community and
+   navigates correctly.
+4. On the home page, scroll to the bottom - the footer link renders, is
+   keyboard-focusable with a visible focus ring, and navigates to the statement.
+5. `cd docs && npm run docs:build` completes without errors or dead-link
+   warnings.
+
+## Files touched
+
+- `docs/accessibility-statement.md` (new)
+- `docs/.vitepress/config.mts` (sidebar group edit)
+- `docs/.vitepress/theme/components/HomePage.vue` (footer block)


### PR DESCRIPTION
## What

Publishes TWD's accessibility statement (audited June 2026 by Latam11y) as a VitePress documentation page.

The statement covers full conformance with **WCAG 2.2 Level AA**, **EN 301 549 v3.2.1**, and the **European Accessibility Act (EU Directive 2019/882)**, for both twd.dev and the twd-js tool.

## Changes

- **New page** `docs/accessibility-statement.md` - adapted from the auditors' standalone HTML into clean VitePress markdown (themed, dark-mode aware, accessible by default). All nine sections: introduction, service overview, how to use TWD, compliance (POUR table + standards + conformance callout + audit details), monitoring, known limitations, disproportionate burden, feedback/contact, document history.
- **Sidebar** - registered under the existing **Community** group in `docs/.vitepress/config.mts`.
- **Home page footer** - the site had no visible footer (custom `layout: false` home, sidebar suppresses the themeConfig footer on doc pages). Added a small semantic `<footer>` to `HomePage.vue` with the accessibility link plus the MIT license / copyright line, which is the conventional home for such a link.

## Notes

- Legal entity filled in as **BRIKEV** (matches the existing copyright holder / GitHub org). Adjust if a different legal name is preferred.
- Dates set to 21 June 2026.
- Escalation subsection omitted (competent-authority details not yet determined).

## Verify

1. `npm run docs:dev`
2. Visit `/accessibility-statement`, confirm sections, table, and info callout render in light and dark themes.
3. Check the **Community** sidebar group for the new entry.
4. Scroll the home page to the footer; tab to the link to confirm a visible focus ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)