### PR TITLE
docs(seo): broaden framework support messaging + structured data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img src="https://raw.githubusercontent.com/BRIKEV/twd/main/images/twd-skill.gif" alt="TWD running with an AI agent: tests written and executed in a real browser sidebar" width="800">
 </p>
 
-> **Frontend tests that run in your real browser.** Same DOM, same routes, same state as your dev server. For React, Vue, Angular, and Solid.
+> **Frontend tests that run in your real browser.** Same DOM, same routes, same state as your dev server. Works with React, Vue, Angular, Solid, Astro, Nuxt, HTMX, and vanilla JS, on Vite, Webpack, or a CDN.
 
 ## The problem
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress'
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "TWD",
-  description: "Test While Developing (TWD) - in-browser testing for React, Vue, Angular, and Solid.js applications",
+  description: "In-browser frontend testing for React, Vue, Angular, Solid, Astro, Nuxt, HTMX and vanilla JS. Runs in your real browser via Vite, Webpack, or a CDN.",
   base: '/',
   cleanUrls: true,
   sitemap: {
@@ -18,7 +18,7 @@ export default defineConfig({
     ['link', { rel: 'manifest', href: '/site.webmanifest' }],
     
     // SEO Meta Tags
-    ['meta', { name: 'keywords', content: 'testing, deterministic, browser-validation, ai-testing, ai-agent, react, vue, angular, solidjs, javascript, typescript, twd, test-while-developing, browser-testing, mock-service-worker, vite, contract-testing, openapi, code-coverage' }],
+    ['meta', { name: 'keywords', content: 'testing, deterministic, browser-validation, ai-testing, ai-agent, react, vue, angular, solidjs, astro, nuxt, react-router, htmx, vanilla-js, javascript, typescript, twd, test-while-developing, browser-testing, mock-service-worker, vite, webpack, cdn, esm, contract-testing, openapi, code-coverage' }],
 
     // Open Graph Tags
     ['meta', { property: 'og:type', content: 'website' }],
@@ -43,7 +43,21 @@ export default defineConfig({
     ['meta', { name: 'viewport', content: 'width=device-width, initial-scale=1.0' }],
 
     // Umami analytics (cookieless, EU region)
-    ['script', { defer: '', src: 'https://cloud.umami.is/script.js', 'data-website-id': '3d4e6e8c-3498-4652-8a3b-f49a734004c8' }]
+    ['script', { defer: '', src: 'https://cloud.umami.is/script.js', 'data-website-id': '3d4e6e8c-3498-4652-8a3b-f49a734004c8' }],
+
+    // Structured data (SoftwareApplication) for rich search results
+    ['script', { type: 'application/ld+json' }, JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: 'TWD (Test While Developing)',
+      applicationCategory: 'DeveloperApplication',
+      operatingSystem: 'Web',
+      description: 'In-browser frontend testing for React, Vue, Angular, Solid, Astro, Nuxt, HTMX and vanilla JS. Runs in your real browser via Vite, Webpack, or a CDN.',
+      url: 'https://twd.dev/',
+      author: { '@type': 'Organization', name: 'BRIKEV', url: 'https://github.com/BRIKEV' },
+      license: 'https://opensource.org/licenses/MIT',
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' }
+    })]
   ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/docs/.vitepress/theme/components/HomePage.vue
+++ b/docs/.vitepress/theme/components/HomePage.vue
@@ -46,7 +46,7 @@ const faqs = [
   },
   {
     q: 'What frameworks are supported?',
-    a: 'React, Vue, Angular, and Solid.js. Anything Vite-based. Not compatible with SSR-first architectures like Next.js App Router (the testing boundary becomes unclear when the server owns rendering).'
+    a: 'Any frontend that renders in the browser: SPAs like React, Vue, Angular, and Solid; hydrated SSR like React Router and Nuxt; Astro islands; and no-build projects like HTMX and vanilla JS via a CDN. On Vite, Webpack, or no bundler at all. The one setup TWD does not target is where the server owns rendering (React Server Components, as in the Next.js App Router), since there is no explicit browser boundary to test there yet.'
   },
   {
     q: 'Can AI actually write good tests?',

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -1,11 +1,11 @@
 ---
 title: Framework Integration
-description: Set up TWD with React, Vue, Angular, Solid.js, CRA, Astro, React Router, and Nuxt
+description: Set up TWD with React, Vue, Angular, Solid, Astro, React Router, Nuxt, Create React App, HTMX, and vanilla JS
 ---
 
 # Framework Integration
 
-TWD is designed to work with any Vite-based application. Currently, **react, vue, angular, solid.js and nuxt are supported**, and the library can be adapted to work with other build tools and frameworks.
+TWD runs your tests in the real browser, so it works with any frontend that renders there: SPAs like React, Vue, Angular, and Solid; hydrated SSR like React Router and Nuxt; Astro islands; and no-build projects like HTMX and vanilla JS, via a CDN. On Vite, Webpack, or no bundler at all.
 
 ## React
 
@@ -715,7 +715,7 @@ TWD is designed for **deterministic frontend boundary validation**. It focuses o
 - **Deterministic behavior** - Predictable rendering and state management
 - **Fast feedback loops** - Quick test execution and hot module replacement
 
-TWD works with SPAs and frameworks where the UI renders client-side and external dependencies can be explicitly isolated. This includes SSR frameworks like **React Router** where loaders and actions are explicit and testable at the boundary. Server-component-first architectures like **Next.js App Router**, where rendering, data loading, and infrastructure are implicitly mixed, blur the ownership boundary and are not compatible with TWD's validation model.
+TWD works with any frontend that renders in the browser and exposes an explicit, testable boundary. This includes SPAs, hydrated SSR frameworks like **React Router** and **Nuxt** where loaders and data fetching are explicit, Astro islands, and no-build projects served from a CDN. The one setup TWD does not target is where the server owns rendering and data-loading together (**React Server Components**, as in the **Next.js App Router**), since there is no explicit browser boundary to test there yet.
 
 TWD officially supports:
 - **React (SPA)** - Standard Vite-based React applications

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,11 +1,11 @@
 ---
 title: Getting Started
-description: Install TWD and write your first in-browser test for React, Vue, Angular, or Solid.js apps
+description: Install TWD and write your first in-browser test for React, Vue, Angular, Solid, Astro, Nuxt, HTMX, or vanilla JS apps
 ---
 
 # Getting Started
 
-Welcome to TWD (Test While Developing)! This guide will help you set up TWD in your application and write your first test. TWD is a deterministic browser validation layer for your frontend boundaries. It works with React, Vue, Angular, Solid.js, React Router (client-side and SSR with explicit loaders/actions), and other Vite-based frameworks.
+Welcome to TWD (Test While Developing)! This guide will help you set up TWD in your application and write your first test. TWD is a deterministic browser validation layer for your frontend boundaries. It works with any frontend that renders in the browser: SPAs (React, Vue, Angular, Solid), hydrated SSR (React Router, Nuxt), Astro islands, and no-build projects (HTMX, vanilla JS) via a CDN, on Vite, Webpack, or no bundler at all.
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: false
-title: TWD - Test While Developing
+title: TWD - Test While Developing | In-browser frontend testing
 ---
 
 <HomePage />

--- a/docs/twd-js.md
+++ b/docs/twd-js.md
@@ -1,13 +1,13 @@
 ---
 title: Frontend tests that run in your real browser — TWD
-description: TWD runs your tests in your dev server with a sidebar that updates as you code. For React, Vue, Angular, and Solid.
+description: TWD runs your tests in your dev server with a sidebar that updates as you code. Works with React, Vue, Angular, Solid, Astro, Nuxt, HTMX, and vanilla JS.
 head:
   - - meta
     - property: og:title
       content: Frontend tests that run in your real browser — TWD
   - - meta
     - property: og:description
-      content: TWD runs your tests in your dev server with a sidebar that updates as you code. For React, Vue, Angular, and Solid.
+      content: TWD runs your tests in your dev server with a sidebar that updates as you code. Works with React, Vue, Angular, Solid, Astro, Nuxt, HTMX, and vanilla JS.
 ---
 
 <LandingHero

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twd-js",
   "version": "1.8.2",
-  "description": "Test While Developing (TWD): in-browser test runner with a live sidebar UI for React, Vue, Angular, and Solid, with built-in API and component mocking.",
+  "description": "Test While Developing (TWD): in-browser test runner with a live sidebar UI. Works with React, Vue, Angular, Solid, Astro, Nuxt, HTMX and vanilla JS, on Vite, Webpack, or a CDN. Built-in API and component mocking.",
   "type": "module",
   "license": "MIT",
   "author": "BRIKEV",


### PR DESCRIPTION
## Why

The docs repeated "React, Vue, Angular, and Solid" in many high-visibility places, which undersells what TWD actually supports and is stale (it omits Astro, React Router, Nuxt, CRA/Webpack, HTMX, and vanilla JS). `frameworks.md` even had a line stating only "react, vue, angular, solid.js and nuxt are supported".

## Positioning

Adopts one canonical statement, reused across surfaces:

> TWD runs your tests in the real browser, so it works with any frontend that renders there: SPAs like React, Vue, Angular, and Solid; hydrated SSR like React Router and Nuxt; Astro islands; and no-build projects like HTMX and vanilla JS, via a CDN. On Vite, Webpack, or no bundler at all.

The boundary is framed around **server-owned rendering (React Server Components / Next.js App Router)**, not the framework, and phrased neutrally. That note is kept only in the homepage FAQ and the Framework Support Philosophy section, out of taglines and meta.

## Changes

- **SEO surfaces**: site meta description, `keywords`, per-page descriptions (`getting-started`, `twd-js`, `frameworks`), README tagline, npm `package.json` description, homepage FAQ.
- **Accuracy**: fixed the outdated `frameworks.md` support line.
- **Structured data**: added a `SoftwareApplication` JSON-LD block (verified it renders into the built homepage).
- **Homepage title**: keyword-enriched (`TWD - Test While Developing | In-browser frontend testing`).

## Verification

- `npm run docs:build` passes, no dead links; JSON-LD present in built `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)