### PR TITLE
docs: add auto-generated llms-full.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ dist
 # vitepress build output
 **/.vitepress/dist
 
+# Auto-generated at build time by scripts/generate-llms-full.mjs
+docs/public/llms-full.txt
+
 # vitepress cache directory
 **/.vitepress/cache
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,8 @@
 # TWD (Test While Developing)
 
-> TWD is an in-browser testing ecosystem for SPAs that runs tests directly in the browser with a sidebar UI for instant visual feedback. It supports React, Vue, Angular, and Solid.js with deterministic, client-side UI testing — and includes an AI workflow that lets agents write, run, and iterate on tests autonomously, plus contract testing that validates every mock against the real OpenAPI spec.
+> TWD is an in-browser testing ecosystem that runs tests directly in the browser with a sidebar UI for instant visual feedback. It works with any frontend that renders in the browser (React, Vue, Angular, Solid, Astro, Nuxt, HTMX, and vanilla JS) on Vite, Webpack, or a CDN, and includes an AI workflow that lets agents write, run, and iterate on tests autonomously, plus contract testing that validates every mock against the real OpenAPI spec.
+
+Full documentation as a single file: https://twd.dev/llms-full.txt
 
 Key features:
 - In-browser test execution with visual sidebar UI
@@ -10,7 +12,7 @@ Key features:
 - CI/CD execution with twd-cli (headless Puppeteer, coverage)
 - Contract testing — validate mocks against OpenAPI specs
 - Token-efficient AI agent testing via WebSocket relay (no Playwright, no screenshots)
-- Multi-framework support (React, Vue, Angular, Solid.js)
+- Multi-framework support: React, Vue, Angular, Solid, Astro, Nuxt, plus HTMX and vanilla JS with no build step (via a CDN)
 - Claude Code plugin and skills for autonomous test writing
 
 ## Philosophy
@@ -31,7 +33,7 @@ Key features:
 - [API Mocking](https://twd.dev/api-mocking): Service worker setup, request mocking patterns, dynamic responses, error handling
 - [Component Mocking](https://twd.dev/component-mocking): MockedComponent wrapper, conditional mocking, error states
 - [Module Mocking](https://twd.dev/module-mocking): Sinon-based module mocking for ESM
-- [Framework Integration](https://twd.dev/frameworks): React, Vue, Angular, Solid.js, CRA, Astro, React Router setup
+- [Framework Integration](https://twd.dev/frameworks): React, Vue, Angular, Solid, Astro, React Router, Nuxt, CRA, HTMX, and vanilla JS setup
 - [Testing Library](https://twd.dev/testing-library): Testing Library integration and selectors
 - [CI Execution](https://twd.dev/ci-execution): twd-cli setup, Puppeteer, GitHub Actions
 - [Coverage](https://twd.dev/coverage): Code coverage reporting

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "conventional-changelog": "conventional-changelog -i CHANGELOG.md",
     "dev": "vite",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:build": "node scripts/generate-llms-full.mjs && vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "copy:mock-sw": "cp dist/mock-sw.js examples/twd-test-app/public/mock-sw.js && cp dist/mock-sw.js examples/tutorial-example/public/mock-sw.js && cp dist/mock-sw.js examples/vue-twd-example/public/mock-sw.js",
     "copy:dist:vue-twd-example": "cp -r dist examples/vue-twd-example/src",

--- a/scripts/generate-llms-full.mjs
+++ b/scripts/generate-llms-full.mjs
@@ -1,0 +1,90 @@
+// Generates docs/public/llms-full.txt: the full TWD documentation concatenated
+// into a single file for LLM ingestion (the companion to the curated llms.txt).
+// Run automatically before `vitepress build` (see package.json docs:build).
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS = join(__dirname, '..', 'docs');
+const SITE = 'https://twd.dev';
+const OUT = join(DOCS, 'public', 'llms-full.txt');
+
+// Preferred order (mirrors docs/public/llms.txt for a coherent read). Any docs
+// not listed here are appended afterwards in alphabetical order.
+const ORDER = [
+  'twd-manifesto.md', 'motivation.md',
+  'twd-js.md', 'twd-relay.md', 'contract-testing.md',
+  'getting-started.md', 'writing-tests.md', 'api-mocking.md', 'component-mocking.md',
+  'module-mocking.md', 'frameworks.md', 'testing-library.md', 'ci-execution.md',
+  'coverage.md', 'ai-overview.md', 'contract-testing-setup.md', 'theming.md',
+  'twd-ai/setup.md', 'twd-ai/writing-tests.md', 'twd-ai/ci-setup.md',
+  'twd-ai/test-gaps.md', 'twd-ai/test-quality.md', 'twd-ai/flow-gallery.md',
+  'claude-plugin.md', 'agents.md', 'ai-remote-testing.md',
+  'api/index.md', 'api/test-functions.md', 'api/twd-commands.md', 'api/assertions.md',
+  'tutorial/index.md', 'tutorial/intro.md', 'tutorial/installation.md', 'tutorial/first-test.md',
+  'tutorial/api-mocking.md', 'tutorial/ci-integration.md', 'tutorial/coverage.md',
+  'tutorial/production-builds.md', 'tutorial/testing-library-selectors.md',
+  'community.md', 'accessibility-statement.md',
+];
+
+// Pages that are Vue-component landing shells with no prose body.
+const SKIP = new Set(['index.md']);
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (['.vitepress', 'public', 'node_modules'].includes(entry)) continue;
+      out.push(...walk(full));
+    } else if (entry.endsWith('.md')) {
+      out.push(relative(DOCS, full).replace(/\\/g, '/'));
+    }
+  }
+  return out;
+}
+
+const stripFrontmatter = (src) => src.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
+const stripHtmlComments = (src) => src.replace(/<!--[\s\S]*?-->/g, '');
+
+function titleOf(src, rel) {
+  const fm = src.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const t = fm && fm[1].match(/^title:\s*(.+)$/m);
+  if (t) return t[1].trim().replace(/^["']|["']$/g, '');
+  const h1 = stripFrontmatter(src).match(/^#\s+(.+)$/m);
+  return h1 ? h1[1].trim() : rel;
+}
+
+function urlOf(rel) {
+  if (rel === 'index.md') return `${SITE}/`;
+  const p = rel.replace(/\/index\.md$/, '/').replace(/\.md$/, '');
+  return `${SITE}/${p}`;
+}
+
+const all = walk(DOCS).filter((rel) => !SKIP.has(rel));
+const ordered = [
+  ...ORDER.filter((f) => all.includes(f)),
+  ...all.filter((f) => !ORDER.includes(f)).sort(),
+];
+
+const header = `# TWD (Test While Developing) - Full Documentation
+
+> In-browser frontend testing for React, Vue, Angular, Solid, Astro, Nuxt, HTMX and vanilla JS. Runs in your real browser via Vite, Webpack, or a CDN. This file concatenates the full TWD documentation for LLM ingestion. For a concise index, see ${SITE}/llms.txt.
+`;
+
+let body = '';
+let count = 0;
+for (const rel of ordered) {
+  const src = readFileSync(join(DOCS, rel), 'utf8');
+  const title = titleOf(src, rel);
+  let content = stripHtmlComments(stripFrontmatter(src)).trim();
+  // Drop the leading H1 (we render our own title + source line for each page).
+  content = content.replace(/^#\s+.+\r?\n+/, '');
+  if (!content) continue;
+  body += `\n\n\n# ${title}\nSource: ${urlOf(rel)}\n\n${content}\n`;
+  count += 1;
+}
+
+writeFileSync(OUT, `${header}${body}\n`, 'utf8');
+console.log(`Wrote ${relative(join(__dirname, '..'), OUT)} (${count} pages)`);


### PR DESCRIPTION
## What

Adds `llms-full.txt` (the full docs concatenated into one file for LLM ingestion), the companion to the existing curated `llms.txt`.

- **`scripts/generate-llms-full.mjs`** (new): walks the docs corpus (41 pages), strips frontmatter and HTML comments, orders pages to mirror `llms.txt`, and writes `docs/public/llms-full.txt`. Skips the component-only homepage.
- **`package.json`**: `docs:build` now runs the generator before VitePress, so the GitHub Pages deploy regenerates and serves it at `twd.dev/llms-full.txt`.
- **`.gitignore`**: the generated `docs/public/llms-full.txt` is a build artifact, always fresh (not committed).
- **`docs/public/llms.txt`**: refreshed the stale "React, Vue, Angular, Solid" framing to match the broadened positioning, and linked to the full file.

## Why

`llms.txt` is a concise index; `llms-full.txt` gives AI tools (Cursor, Copilot, Claude, Perplexity) the entire documentation in one fetch. GitMCP and DeepWiki also read these files.

## Verification

- `npm run docs:build` generates 41 pages and both `llms.txt` and `llms-full.txt` end up in `dist/` (deployed). No dead links.
- Generated file stays gitignored (confirmed not staged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)