### PR TITLE
feat(pace): command pacing for recorded runs

### DIFF
--- a/specs/2026-07-27-twd-js-pacing-and-overlays-design.md
+++ b/specs/2026-07-27-twd-js-pacing-and-overlays-design.md
@@ -1,0 +1,135 @@
+# Paced command loop and in-page overlays for recorded runs - Design
+
+Date: 2026-07-27
+Status: Direction only. Not ready to plan. Blocked on twd-cli video capture shipping first.
+Repo: `twd` (twd-js)
+
+## Context
+
+`twd-cli` is getting video capture of a test run. See
+`twd-cli/docs/superpowers/specs/2026-07-27-cli-video-recording-design.md`, which
+covers the whole capture pipeline (ffmpeg, `page.screencast()`, framing, config,
+artifact naming) and requires no twd-js changes.
+
+That spec ships a watchable recording, but the only pacing control it has is
+`record.speed`, a uniform ffmpeg `setpts` stretch of the entire timeline. It
+slows the fast parts and the already-slow parts equally and cannot hold on a
+just-clicked element.
+
+This document covers the twd-js half, which is where the actual differentiator
+lives.
+
+## Why this is the differentiator
+
+Cypress and Playwright videos run fast because the video is a byproduct of a
+driver hammering the browser at full speed. Their `slowMo` and padding only tweak
+protocol timing.
+
+TWD's commands (`get`, `userEvent` interactions, `should` assertions) execute as
+JavaScript inside the page, and twd-cli drives the browser around that in-page
+runner. TWD owns its own command loop, so it can space commands deliberately and
+produce a video where the execution itself is paced, not the recording.
+
+It can also draw overlays directly in the page (highlight the element being acted
+on, flash the assertion target, render the current step as a caption) that get
+baked into the video file. Cypress and Playwright can only add that kind of
+annotation after the fact in a trace viewer.
+
+## Packaging
+
+Pacing and overlay rendering ship as a separate `twd-js/record` entry, injected
+by twd-cli via `page.addScriptTag` before the run starts.
+
+This keeps overlay DOM and CSS out of the bundle for the users who never record,
+which is nearly all of them. Bundling it in core would not be tree-shakeable,
+because it would be reached through a runtime flag rather than a static import.
+
+The core needs one small always-present hook point for the injected module to
+attach to.
+
+## Constraints already identified
+
+These came out of reading the current implementation and should not have to be
+rediscovered.
+
+### `should()` is a synchronous chainable
+
+`twd.ts:319` and `twd.ts:346` return `api` synchronously so calls can chain
+(`items.at(0).should(...).should(...)`). Awaiting a pacing delay inside it would
+be a breaking API change.
+
+Pace the already-async commands instead: `get`, `getAll`, `userEvent.*`,
+`screenDom.*`, `visit`, `waitFor`, `notExists`. Let an assertion's overlay persist
+into the following command's dwell window rather than giving assertions a dwell
+of their own.
+
+### The delay goes after the command, not before
+
+`get()` resolving and then dwelling naturally produces "highlight the element,
+hold, then act", which is the Cypress command-log feel. It falls out of the
+existing call order for free, with no reordering.
+
+### `log()` is the natural chokepoint but is synchronous
+
+`src/utils/log.ts` is called from every command that would need pacing, which
+makes it the right place to hang the hook. Its `(msg: string) => void` signature
+has to change for the async call sites.
+
+Its call sites are already enumerated: `twd.ts` (get, getAll, should, notExists),
+`proxies/userEvent.ts`, `proxies/screenDom.ts`, `commands/url.ts`,
+`commands/visit.ts`, `commands/viewport.ts`, `utils/waitFor.ts`.
+
+### Overlays cannot be plain `<body>` children
+
+`twd.get` scopes queries with `body > div:not(#twd-sidebar-root) ${selector}`
+(`twd.ts:313`), so an overlay div appended to body becomes a candidate ancestor
+and can pollute `getAll` results.
+
+Overlays must render in a shadow root or inside the existing sidebar root. The
+scoping selector should be reviewed either way, since it is fragile to any new
+top-level container.
+
+### Overlay text is already available
+
+The strings passed to `log()` are human-readable command descriptions
+(`Searching get("...")`, the `eventsMessage` and `domMessage` output). They can
+drive the step caption directly with no new message layer.
+
+## Related: screenshots on failure
+
+A separate feature, but it needs two of the same changes and should be sequenced
+with this work.
+
+- **An event bridge.** Node cannot observe per-test outcomes mid-chunk, because
+  twd-cli runs an entire chunk inside one `page.evaluate()`. The fix is
+  `page.exposeFunction`, following the existing `__twdCollectMock` precedent, with
+  the in-page callback awaiting it so the page pauses while Node captures.
+- **Awaited runner events.** `runner.ts:364-382` calls `onStart`, `onPass`, and
+  `onFail` without `await`, and `RunnerEvents` types them as returning `void`.
+  Both need to allow and await a promise.
+
+Two behaviors to resolve when that is specced:
+
+- **`onFail` fires after `afterEach`.** The `finally` block at `runner.ts:377-379`
+  runs the after hooks before `onFail` at line 382, so a screenshot taken at
+  `onFail` captures post-cleanup DOM rather than the failure state. This likely
+  needs a new hook inside the `catch`.
+- **Retries.** With `retryCount` defaulting to 2, hooking the `catch` yields one
+  screenshot per failed attempt. Decide between capturing every attempt and
+  capturing only the final failure.
+
+Once the bridge exists, per-test video files also become possible, and the
+one-clip-per-run constraint in the twd-cli spec can be revisited.
+
+## Open questions
+
+- The pace value should be configurable, since a CI debug artifact wants
+  real-time or mild slow-mo while a demo video wants a slower narration feel.
+  Where that value is set, and how twd-cli passes it into the injected module,
+  is not yet decided.
+- Whether the sidebar should be hidden during capture is currently a twd-cli
+  concern (a CSS injection). If overlays render inside the sidebar root, that
+  interacts, and the two need to be designed together.
+- Whether the pacing hook should also serve the future in-browser
+  (`getDisplayMedia`) capture path, which would argue for putting it somewhere
+  the sidebar can reach without twd-cli injecting it.

--- a/specs/2026-07-27-twd-js-pacing-and-overlays-design.md
+++ b/specs/2026-07-27-twd-js-pacing-and-overlays-design.md
@@ -1,8 +1,23 @@
 # Paced command loop and in-page overlays for recorded runs - Design
 
 Date: 2026-07-27
-Status: Direction only. Not ready to plan. Blocked on twd-cli video capture shipping first.
+Status: Superseded for the pacing half. Retained for the overlay research.
 Repo: `twd` (twd-js)
+
+> **Superseded by [`2026-07-28-twd-js-command-pacing-design.md`](./2026-07-28-twd-js-command-pacing-design.md).**
+>
+> That spec is the plan of record for pacing, and it deliberately drops overlays:
+> the only reason to pause after a query is to highlight what it found, so
+> overlays and query pacing stand or fall together, and v1 paces actions only.
+>
+> Two things below are also now known to be wrong. `log()` is not a usable hook
+> point, because it is synchronous and making it async would force `await` into
+> `should()` and the `screenDom` proxy. And the enablement surface is a
+> `window.__twdSetPace` tooling global, not a public `twd` API method, so a stray
+> call cannot slow CI.
+>
+> This document is kept for the overlay investigation, which remains accurate and
+> would be the starting point if overlays are ever revisited.
 
 ## Context
 

--- a/specs/2026-07-28-twd-js-command-pacing-design.md
+++ b/specs/2026-07-28-twd-js-command-pacing-design.md
@@ -1,0 +1,326 @@
+# Command pacing for recorded runs - Design
+
+Date: 2026-07-28
+Status: Ready to plan
+Repos: `twd` (twd-js, the pacing hook) and `twd-cli` (one config key and one call)
+
+## Problem
+
+`twd-cli` can now record a video of a test run. See
+`twd-cli/docs/superpowers/specs/2026-07-27-cli-video-recording-design.md`.
+
+The recording is correct but too fast to watch. Measured on `twd-vue-example`:
+two tests produced a 1.17 second clip. That is the honest execution time, and no
+amount of work inside twd-cli can change it.
+
+`record.speed` exists as a stopgap, but it is an ffmpeg `setpts` filter applied
+after the fact. It stretches the timeline uniformly without adding frames, so the
+effective frame rate falls in proportion. Measured: identical page activity at
+`speed: 1` gives 1.00s at 30fps, at `0.5` gives 1.90s at 15.3fps, at `0.25` gives
+3.90s at 7.7fps. It slows the dead air exactly as much as the interesting
+moments, and it costs frame rate to do it.
+
+TWD's commands execute as JavaScript inside the page, so TWD owns its own command
+loop. It can space commands deliberately at full frame rate, which is what makes
+this different from Cypress and Playwright, where the video is a byproduct of a
+driver running at machine speed.
+
+## Primary use case
+
+A watchable clip of a single flow, produced by twd-cli:
+
+```
+npx twd-cli run --record --record-pace 500 --test "checkout flow"
+```
+
+## Scope
+
+In scope: a pacing hook in twd-js, and the twd-cli change that drives it. Neither
+half is useful alone, so they share this spec and ship as two pull requests.
+
+Out of scope: in-page overlays. See "Overlays, considered and dropped".
+
+## Hard constraints
+
+These are the shape of the design, not preferences.
+
+1. **A normal test run must be unaffected.** Not "barely affected". No timers, no
+   promise allocations, no behavior change when pacing is off.
+2. **No public API may become asynchronous.** Several TWD APIs are synchronous
+   today and making them async to fit pacing would be a breaking change.
+3. **Pacing must be impossible to enable by accident.** A stray call left in a
+   spec file must not be able to slow CI.
+
+## Design
+
+### The pace module
+
+One new file, `src/pace.ts`:
+
+```ts
+const MAX_PACE_MS = 5000;
+
+let paceMs = 0;
+let keyDelayMs = 0;
+
+/** Tooling hook. Deliberately not exported from src/index.ts. */
+export const setPace = (ms: unknown): number => {
+  const valid = typeof ms === 'number' && Number.isFinite(ms) && ms > 0;
+  paceMs = valid ? Math.min(ms as number, MAX_PACE_MS) : 0;
+  keyDelayMs = paceMs ? Math.min(60, Math.round(paceMs / 10)) : 0;
+  return paceMs;
+};
+
+export const getKeyDelay = (): number => keyDelayMs;
+
+/** Returns undefined synchronously when pacing is off. */
+export const pace = (): void | Promise<void> => {
+  if (!paceMs) return;
+  return wait(paceMs);
+};
+
+if (typeof window !== 'undefined') {
+  window.__twdSetPace = setPace;
+}
+```
+
+`wait` is the existing helper in `src/utils/wait.ts`. The window registration
+mirrors `window.__testRunner = TestRunner` at `src/runner.ts:386`, so it follows
+a pattern twd-cli already consumes rather than inventing one. `__twdSetPace` is
+declared in `src/global.d.ts` beside the other globals.
+
+`setPace` returns the value actually applied, so twd-cli can report what took
+effect after clamping.
+
+### One number, two scales
+
+The caller passes a single number. The typing delay is derived from it, clamped
+at 60ms so a long pace does not make typing crawl.
+
+| `setPace(ms)` | between actions | per keystroke |
+|---|---|---|
+| `200` | 200ms | 20ms |
+| `500` | 500ms | 50ms |
+| `2000` | 2000ms | 60ms (clamped) |
+
+Two scales are unavoidable. The library's `delay` is uniform, so a 500ms value
+would put 500ms between every keystroke and a ten character field would take five
+seconds to fill.
+
+### What gets paced
+
+`await pace()` is added only where the code is **already** asynchronous:
+
+- `src/proxies/userEvent.ts`, at the end of the generic wrapper and of the three
+  special-cased wrappers (`type`, `clear`, `keyboard`), after the existing `log`
+  call. Not on `setup`, which returns an instance rather than performing an
+  action.
+- `src/commands/visit.ts`.
+
+The delay goes **after** the action, so the viewer sees its result. A delay
+before an action shows a still frame of nothing happening.
+
+### What is deliberately not paced
+
+Recorded here so nobody "completes" it later.
+
+| Not paced | Why |
+|---|---|
+| `should()` (`twd.ts:319`, `twd.ts:346`) | A synchronous chainable. Pacing it means making it async, a breaking change. |
+| `twd.setInputValue()` | Synchronous, same reason. |
+| `screenDom.*` (`screenDom.ts:110-113`) | A pass-through proxy: synchronous for `getBy*`, a promise for `findBy*`. No uniform hook, and it is a query. |
+| `twd.get` / `getAll` / `waitFor` | Queries do not change the page. Without highlighting, a pause after one is dead air. |
+| `twd.wait` / `twd.waitFor` | Already delays. |
+
+### The user-event `delay` option
+
+`@testing-library/user-event` (14.6.1) takes a `delay` config option, and it is
+applied in four places, not one:
+
+| Location | Effect |
+|---|---|
+| `setup/setup.js:86`, inside `wrapAndBindImpl` | a trailing wait after **every** API method |
+| `keyboard/index.js:10,24` | between keystrokes |
+| `pointer/index.js:26` | between pointer actions |
+| `utility/selectOptions.js:77,99` | between option selections |
+
+Because it is config-level, the clean way to apply it is a cached setup instance
+rather than merging options into each call. The cache is keyed on the delay so a
+second `setPace` call cannot leave a stale instance behind, which a plain
+`instance ??= ...` would:
+
+```ts
+// module scope in src/proxies/userEvent.ts
+let cached: { delay: number; user: UserEvent } | null = null;
+
+const pacedUser = (delay: number): UserEvent => {
+  if (!cached || cached.delay !== delay) {
+    cached = { delay, user: userEventLib.setup({ delay }) };
+  }
+  return cached.user;
+};
+```
+
+Each wrapper then picks its target once:
+
+```ts
+const delay = getKeyDelay();
+const target = delay ? pacedUser(delay) : userEventLib;
+```
+
+That covers every method uniformly, needs no knowledge of per-method argument
+positions, and avoids the fact that `clear(element)` is the one direct API method
+that accepts no options at all.
+
+For the user-facing `setup()` branch of the proxy, the delay is merged so an
+explicit caller option still wins:
+
+```ts
+orig({ delay: getKeyDelay(), ...(args[0] || {}) })
+```
+
+When pacing is off, the proxy uses the direct API exactly as it does today and
+no instance is created.
+
+### Behavior change to accept, not work around
+
+The direct API builds a fresh `System` per call. A setup instance shares pointer
+and keyboard state across calls, so the pointer stays where the previous action
+left it. That is the library's own recommended usage and arguably more realistic,
+but it is a difference.
+
+It applies only when pacing is on, which only happens inside a recorded run, and
+recorded runs are already documented as not a substitute for a CI run. Accept it
+and document it.
+
+### The zero-cost guarantee
+
+`pace()` returns `undefined` synchronously when disabled: no promise allocated,
+no timer scheduled, no `setup()` instance created. The only residue is that
+`await undefined` costs one microtask per call site, which is sub-microsecond; a
+ten thousand command suite pays single digit milliseconds in total.
+
+This is pinned by test rather than asserted in prose. See Testing.
+
+## Enablement
+
+`window.__twdSetPace(ms)` is the only way in. It is not exported from
+`src/index.ts`, so it never appears in the public `twd` object or its published
+types.
+
+This was chosen over a public `twd.setPace()` specifically because of constraint
+3: a documented API method can be left in a spec file, and every future CI run
+would then be slower with no obvious cause. Anyone who wants it interactively can
+still call it from the devtools console.
+
+Invalid input (non-numeric, `NaN`, negative, zero) sets the pace to 0 rather than
+throwing, and values above `MAX_PACE_MS` are clamped, so a typo cannot hang a run.
+
+## The twd-cli side
+
+A `record.pace` key defaulting to `0`, a `--record-pace <ms>` flag, and one call
+placed after `startRecording` and before `holdOpeningFrame`:
+
+```js
+if (record.pace) {
+  const applied = await page.evaluate((ms) => window.__twdSetPace(ms), record.pace);
+  if (applied !== record.pace) {
+    console.warn(`Pace clamped to ${applied}ms.`);
+  }
+}
+```
+
+Gated on `record.enabled`, so pacing can only ever happen inside a recorded run.
+
+`record.pace` follows the existing nested-`record` merge in `src/config.js`, and
+`--record-pace` joins the existing three flags in `src/parseArgs.js`.
+
+## Risks
+
+**Pacing can hide flakiness.** Half a second between every action makes race
+conditions vanish. A paced run is even less representative of CI than a recorded
+run already is. This belongs next to the existing non-determinism warning in the
+twd-cli README, not buried.
+
+**Pacing can exceed `protocolTimeout`.** A chunk is `chunkSize` tests (default 10)
+inside a single `page.evaluate`, bounded by `protocolTimeout` (default 300000ms).
+Ten tests at twenty actions each with a 500ms pace is 100 seconds of pure pacing
+in one chunk, before the tests do any work of their own. The guidance is to pace
+with a `--test` filter. For a paced full-suite run, raise `protocolTimeout` or
+lower `chunkSize`.
+
+**The focus fallback bypasses the key delay.** `src/proxies/userEvent.ts` falls
+back to a native-setter path when `document.visibilityState === 'hidden'` or
+`document.hasFocus()` is false, which writes the whole value in one shot. Those
+paths still get the between-action `pace()`, but `keyDelay` cannot apply.
+Measured: Puppeteer reports `visibilityState: 'visible'` and `hasFocus: true` in
+both headless and headed mode, so this does not affect recordings. It would
+affect the twd-relay workflow, where nothing is being recorded.
+
+## Overlays, considered and dropped
+
+The earlier draft proposed in-page overlays: highlight the element being acted
+on, flash the assertion target, render the current step as a caption.
+
+Dropped for v1, because overlays and query-pacing stand or fall together. The
+only reason to pause after `twd.get()` is to show the viewer what was found, and
+without a highlight that pause is a still frame of nothing. Dropping overlays
+therefore also removes query pacing, which is most of the surface area.
+
+Constraints found while investigating, preserved in case overlays are revisited:
+
+- Overlays cannot be plain `<body>` children. `twd.get` scopes queries with
+  `body > div:not(#twd-sidebar-root) ${selector}` (`twd.ts:313`), so an overlay
+  div becomes a candidate ancestor and can pollute `getAll` results. They would
+  need a shadow root.
+- Overlays interact with twd-cli's framing, which hides `#twd-sidebar-root` and
+  zeroes the html margins during capture. Rendering overlays inside the sidebar
+  root would hide them too. The two must be designed together.
+- Overlay text is already available: the strings passed to `log()` are
+  human-readable command descriptions.
+
+## Testing
+
+In `twd` (Vitest, `src/tests/` mirroring the source):
+
+- `setPace` validation: a positive number is stored, values above the ceiling are
+  clamped, and `0`, negatives, `NaN`, `undefined` and non-numbers all disable it.
+  The return value reports what was applied.
+- The derived key delay across the table above, including the 60ms clamp.
+- **`pace()` returns `undefined`, not a Promise, when disabled.** This is the
+  zero-cost invariant. It fails loudly if someone later makes `pace` an `async`
+  function, which would silently allocate a promise on every command.
+- `window.__twdSetPace` is registered, and `setPace` is NOT exported from
+  `src/index.ts`. The second half is the guard on constraint 3.
+- The userEvent proxy delays after an action when paced and does not when not,
+  using fake timers rather than real waits.
+- The proxy uses the direct API when pacing is off and a setup instance when it
+  is on, and a caller-supplied `delay` in `setup()` wins over the derived one.
+- Changing the pace mid-session produces an instance with the new delay rather
+  than reusing the previous one. This pins the cache-invalidation bug that a
+  plain `instance ??= ...` would introduce.
+
+In `twd-cli`, following its one-test-file-per-module convention:
+
+- `config.test.js`: `record.pace` default and partial merge.
+- `parseArgs.test.js`: `--record-pace` in both flag forms, and rejection of
+  non-numeric values.
+- `runTests.test.js`: `__twdSetPace` is called when recording with a pace set,
+  not called when the pace is 0, and not called when recording is disabled.
+
+## Open questions
+
+- Whether a good default pace exists, or whether `--record-pace` should stay
+  opt-in with no default. Leaning opt-in, since the right value depends on the
+  app.
+- Whether `twd.viewport()` deserves pacing. It changes layout visibly, but it is
+  rare in tests and the wiring is not free.
+- Whether pacing should eventually serve an in-browser capture path, which would
+  argue for a different enablement surface than a window global.
+
+## Value
+
+The differentiator the recording feature was built for. Cypress and Playwright
+can only stretch a video after the fact, losing frame rate as they go. TWD owns
+the in-page command loop, so it can space the execution itself and produce a
+watchable clip at full frame rate, from tests the user already has.

--- a/specs/2026-07-28-twd-js-command-pacing-plan.md
+++ b/specs/2026-07-28-twd-js-command-pacing-plan.md
@@ -1,0 +1,661 @@
+# twd-js Command Pacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a recorded twd-cli run space out its commands so the video is watchable, without touching normal test runs.
+
+**Architecture:** One new module (`src/pace.ts`) holds a single number and exposes it through a `window.__twdSetPace` tooling global. Two existing files gain an `await pace()` after actions they already perform asynchronously. The user-event proxy additionally routes through a cached `setup({ delay })` instance when paced, so keystrokes are spaced too.
+
+**Tech Stack:** TypeScript, Vitest with jsdom, `@testing-library/user-event` 14.6.1.
+
+Spec: `specs/2026-07-28-twd-js-command-pacing-design.md`
+
+## Global Constraints
+
+- Repo is `/Users/kevinccbsg/brikev/twd`. This plan does NOT touch `twd-cli`; that is a separate plan.
+- **A normal test run must be unaffected.** No timers, no promise allocations, no behavior change when pacing is off.
+- **No public API may become asynchronous.** `should()`, `twd.setInputValue()` and the `screenDom` proxy are synchronous today and must stay that way.
+- **`setPace` must NOT be exported from `src/index.ts`** and must not appear on the public `twd` object. A documented API method could be left in a spec file and would silently slow every future CI run.
+- Exact values from the spec: `MAX_PACE_MS = 5000`, key delay is `Math.min(60, Math.round(paceMs / 10))`, and invalid input (non-number, `NaN`, negative, zero) means a pace of `0`.
+- Tests live in `src/tests/` mirroring the source tree, named `*.spec.ts`, using Vitest.
+- Conventional Commits.
+- **Commit messages must NOT contain any `Co-Authored-By` trailer or Claude Code attribution.** End the message at its last content line.
+- Do not use em-dashes in code, comments, prose, or commit messages.
+- Do not add public documentation for `__twdSetPace`. It is deliberately not public API; documenting it would undercut the design.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/pace.ts` (new) | Owns the pace value, derives the key delay, exposes the window hook. |
+| `src/global.d.ts` (modify) | Declares `__twdSetPace` beside the other globals. |
+| `src/proxies/userEvent.ts` (modify) | Pauses after interactions; routes through a paced setup instance. |
+| `src/commands/visit.ts` (modify) | Pauses after navigation. |
+| `src/tests/pace.spec.ts` (new) | The module's behavior and the zero-cost invariant. |
+| `src/tests/proxies/userEventPacing.spec.ts` (new) | Proxy wiring, against a mocked user-event library. |
+
+---
+
+### Task 1: The pace module
+
+**Files:**
+- Create: `src/pace.ts`
+- Modify: `src/global.d.ts`
+- Test: `src/tests/pace.spec.ts`
+
+**Interfaces:**
+- Consumes: `wait` from `src/utils/wait.ts` (existing: `wait(time: number): Promise<void>`).
+- Produces:
+  - `setPace(ms: unknown): number` returns the value actually applied after validation and clamping
+  - `getKeyDelay(): number`
+  - `getPaceGeneration(): number` increments on every `setPace` call, so consumers can invalidate cached state
+  - `pace(): void | Promise<void>` returns `undefined` synchronously when disabled
+  - `window.__twdSetPace` bound to `setPace`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/pace.spec.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setPace, getKeyDelay, getPaceGeneration, pace } from '../pace';
+
+describe('setPace', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  it('stores and returns a positive pace', () => {
+    expect(setPace(500)).toBe(500);
+  });
+
+  it('clamps to the 5000ms ceiling so a typo cannot hang a run', () => {
+    expect(setPace(99999)).toBe(5000);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['a negative number', -100],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', '500'],
+    ['an object', {}],
+  ])('treats %s as disabled rather than throwing', (_label, input) => {
+    expect(setPace(input)).toBe(0);
+    expect(getKeyDelay()).toBe(0);
+  });
+});
+
+describe('getKeyDelay', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  it.each([
+    [200, 20],
+    [500, 50],
+    [600, 60],
+    [2000, 60],
+  ])('derives %ims pace into a %ims key delay', (paceMs, expected) => {
+    setPace(paceMs);
+    expect(getKeyDelay()).toBe(expected);
+  });
+});
+
+describe('pace', () => {
+  afterEach(() => {
+    setPace(0);
+    vi.useRealTimers();
+  });
+
+  // This is the zero-cost invariant. It fails if someone later makes `pace` an
+  // `async` function, which would silently allocate a promise on every command.
+  it('returns undefined and not a Promise when disabled', () => {
+    setPace(0);
+    const result = pace();
+    expect(result).toBeUndefined();
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+
+  it('returns a Promise when enabled', () => {
+    setPace(500);
+    expect(pace()).toBeInstanceOf(Promise);
+  });
+
+  it('resolves only after the configured delay', async () => {
+    vi.useFakeTimers();
+    setPace(500);
+    let resolved = false;
+    const pending = Promise.resolve(pace()).then(() => { resolved = true; });
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(resolved).toBe(true);
+  });
+});
+
+describe('getPaceGeneration', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  // Task 3 caches a user-event instance built from the key delay. Keying that
+  // cache on the delay alone is not enough, because setting the same value
+  // twice must still invalidate. The generation makes invalidation exact.
+  it('increments on every setPace call, including a repeat of the same value', () => {
+    const start = getPaceGeneration();
+
+    setPace(500);
+    expect(getPaceGeneration()).toBe(start + 1);
+
+    setPace(500);
+    expect(getPaceGeneration()).toBe(start + 2);
+
+    setPace(0);
+    expect(getPaceGeneration()).toBe(start + 3);
+  });
+});
+
+describe('the window hook', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  it('exposes setPace as window.__twdSetPace', () => {
+    expect(window.__twdSetPace).toBe(setPace);
+    expect(window.__twdSetPace!(300)).toBe(300);
+  });
+});
+
+describe('public API surface', () => {
+  it('does not leak setPace out of the package entry point', async () => {
+    const publicApi = await import('../index');
+    expect(Object.keys(publicApi)).not.toContain('setPace');
+    expect(Object.keys(publicApi)).not.toContain('pace');
+  });
+
+  it('does not put setPace on the twd object', async () => {
+    const { twd } = await import('../twd');
+    expect('setPace' in twd).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest --run src/tests/pace.spec.ts`
+Expected: FAIL, cannot resolve `../pace`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/pace.ts`:
+
+```ts
+import { wait } from './utils/wait';
+
+const MAX_PACE_MS = 5000;
+const MAX_KEY_DELAY_MS = 60;
+
+let paceMs = 0;
+let keyDelayMs = 0;
+let generation = 0;
+
+/**
+ * Sets the delay inserted after each paced command, in milliseconds.
+ *
+ * This is a tooling hook for twd-cli, deliberately not exported from
+ * src/index.ts. Pacing is only ever wanted inside a recorded run, and a public
+ * API method could be left behind in a spec file, silently slowing every future
+ * CI run with no obvious cause.
+ *
+ * Invalid input disables pacing rather than throwing, and large values are
+ * clamped, so a typo cannot hang a run.
+ *
+ * @returns the pace actually applied
+ */
+export const setPace = (ms: unknown): number => {
+  paceMs =
+    typeof ms === 'number' && Number.isFinite(ms) && ms > 0
+      ? Math.min(ms, MAX_PACE_MS)
+      : 0;
+  keyDelayMs = paceMs ? Math.min(MAX_KEY_DELAY_MS, Math.round(paceMs / 10)) : 0;
+  generation += 1;
+  return paceMs;
+};
+
+/**
+ * Bumped by every setPace call, so consumers holding derived state can tell it
+ * is stale. Keying such a cache on the delay alone is not enough: setting the
+ * same value twice must still invalidate.
+ */
+export const getPaceGeneration = (): number => generation;
+
+/**
+ * The per-keystroke delay derived from the pace.
+ *
+ * A separate, much smaller scale is unavoidable: user-event applies `delay`
+ * uniformly, so reusing the pace itself would put half a second between every
+ * character.
+ */
+export const getKeyDelay = (): number => keyDelayMs;
+
+/**
+ * Returns undefined synchronously when pacing is off, so a normal run allocates
+ * no promise and schedules no timer. Do not make this an async function.
+ */
+export const pace = (): void | Promise<void> => {
+  if (!paceMs) return;
+  return wait(paceMs);
+};
+
+if (typeof window !== 'undefined') {
+  window.__twdSetPace = setPace;
+}
+```
+
+- [ ] **Step 4: Declare the global**
+
+In `src/global.d.ts`, add to the `Window` interface alongside the existing entries:
+
+```ts
+    __twdSetPace?: (ms: unknown) => number;
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest --run src/tests/pace.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npx vitest --run`
+Expected: PASS, no previously passing test broken.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pace.ts src/global.d.ts src/tests/pace.spec.ts
+git commit -m "feat(pace): add the command pacing module and window hook"
+```
+
+---
+
+### Task 2: Pause after actions
+
+Adds the between-action beat. This is the part that makes a recorded run watchable.
+
+**Files:**
+- Modify: `src/proxies/userEvent.ts`
+- Modify: `src/commands/visit.ts`
+- Test: `src/tests/proxies/userEventPacing.spec.ts`
+
+**Interfaces:**
+- Consumes: `pace` from `src/pace.ts` (Task 1), `setPace` in tests.
+- Produces: nothing new. Both files keep their existing exports and signatures.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/tests/proxies/userEventPacing.spec.ts`. The user-event library is mocked so the test asserts wiring rather than real event timing, which is already covered by the existing `userEvent.spec.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const instanceApi = {
+  click: vi.fn().mockResolvedValue(undefined),
+  type: vi.fn().mockResolvedValue(undefined),
+  clear: vi.fn().mockResolvedValue(undefined),
+  keyboard: vi.fn().mockResolvedValue(undefined),
+};
+
+const directApi = {
+  click: vi.fn().mockResolvedValue(undefined),
+  type: vi.fn().mockResolvedValue(undefined),
+  clear: vi.fn().mockResolvedValue(undefined),
+  keyboard: vi.fn().mockResolvedValue(undefined),
+};
+
+const setupMock = vi.fn(() => instanceApi);
+
+vi.mock('@testing-library/user-event', () => ({
+  default: { ...directApi, setup: setupMock },
+}));
+
+vi.mock('../../pace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../pace')>();
+  return { ...actual, pace: vi.fn() };
+});
+
+import { userEvent } from '../../proxies/userEvent';
+import { setPace, pace } from '../../pace';
+
+describe('userEvent pacing', () => {
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPace(0);
+    input = document.createElement('input');
+    document.body.appendChild(input);
+  });
+
+  afterEach(() => {
+    setPace(0);
+    input.remove();
+  });
+
+  it('paces after an interaction', async () => {
+    await userEvent.click(input);
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('paces after typing', async () => {
+    await userEvent.type(input, 'hello');
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('paces after clearing', async () => {
+    await userEvent.clear(input);
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('paces after keyboard input', async () => {
+    input.focus();
+    await userEvent.keyboard('abc');
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not pace on setup, which performs no action', () => {
+    userEvent.setup();
+    expect(pace).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest --run src/tests/proxies/userEventPacing.spec.ts`
+Expected: FAIL, `pace` is never called.
+
+- [ ] **Step 3: Add the shared helper to the userEvent proxy**
+
+In `src/proxies/userEvent.ts`, add the import and a helper above `createLoggedProxy`:
+
+```ts
+import { pace } from '../pace';
+```
+
+```ts
+/**
+ * Logs the command and then holds, so a recorded run shows the result of the
+ * action before moving on. `pace()` is a no-op when pacing is off.
+ */
+async function logAndPace(prefix: string, prop: string | symbol, args: any[]) {
+  log(eventsMessage(prefix, prop, args));
+  await pace();
+}
+```
+
+- [ ] **Step 4: Route every action path through the helper**
+
+In `src/proxies/userEvent.ts`, replace each `log(eventsMessage(prefix, prop, args));` with `await logAndPace(prefix, prop, args);` in these seven places:
+
+1. the `type` fallback path
+2. the `type` normal path
+3. the `clear` fallback path
+4. the `clear` normal path
+5. the `keyboard` fallback path (the one after `flushText()`, not the early return)
+6. the `keyboard` normal path
+7. the generic wrapper at the bottom
+
+Leave the `keyboard` early return that fires when there is no active element as a plain `log(...)` call. It performed no action, so there is nothing to hold on.
+
+Do not touch the `setup` branch.
+
+- [ ] **Step 5: Pace after navigation**
+
+In `src/commands/visit.ts`, add the import and a hold at the very end of `visit`:
+
+```ts
+import { pace } from '../pace';
+```
+
+```ts
+  window.history.pushState({}, '', url);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+  await wait(DELAY);
+  await pace();
+};
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest --run src/tests/proxies/userEventPacing.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npx vitest --run`
+Expected: PASS. The existing `src/tests/proxies/userEvent.spec.ts` must be unchanged and still green, since pacing defaults to off.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/proxies/userEvent.ts src/commands/visit.ts src/tests/proxies/userEventPacing.spec.ts
+git commit -m "feat(pace): hold after interactions and navigation when paced"
+```
+
+---
+
+### Task 3: Space out keystrokes
+
+Adds the within-action delay. user-event applies its `delay` option at config level, in `wrapAndBindImpl` (`setup/setup.js:86`) after every API method, plus between keystrokes, pointer actions and option selections. So the delay is applied by routing through a setup instance rather than by merging options into each call, which also sidesteps `clear(element)` being the one direct API method that accepts no options.
+
+**Files:**
+- Modify: `src/proxies/userEvent.ts`
+- Test: `src/tests/proxies/userEventPacing.spec.ts`
+
+**Interfaces:**
+- Consumes: `getKeyDelay` from `src/pace.ts` (Task 1).
+- Produces: nothing new. The `userEvent` export keeps its type and shape.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tests/proxies/userEventPacing.spec.ts`, inside the existing file (the mocks at the top already cover this):
+
+```ts
+describe('userEvent key delay', () => {
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPace(0);
+    input = document.createElement('input');
+    document.body.appendChild(input);
+  });
+
+  afterEach(() => {
+    setPace(0);
+    input.remove();
+  });
+
+  it('uses the direct API and creates no instance when pacing is off', async () => {
+    await userEvent.click(input);
+
+    expect(setupMock).not.toHaveBeenCalled();
+    expect(directApi.click).toHaveBeenCalledTimes(1);
+    expect(instanceApi.click).not.toHaveBeenCalled();
+  });
+
+  it('routes through a setup instance carrying the derived delay when paced', async () => {
+    setPace(500);
+
+    await userEvent.click(input);
+
+    expect(setupMock).toHaveBeenCalledWith({ delay: 50 });
+    expect(instanceApi.click).toHaveBeenCalledTimes(1);
+    expect(directApi.click).not.toHaveBeenCalled();
+  });
+
+  it('reuses the cached instance across calls at the same pace', async () => {
+    setPace(500);
+
+    await userEvent.click(input);
+    await userEvent.click(input);
+
+    expect(setupMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A plain `instance ??= setup(...)` would keep the stale 50ms delay here.
+  it('rebuilds the instance when the pace changes', async () => {
+    setPace(500);
+    await userEvent.click(input);
+
+    setPace(200);
+    await userEvent.click(input);
+
+    expect(setupMock).toHaveBeenCalledTimes(2);
+    expect(setupMock).toHaveBeenNthCalledWith(1, { delay: 50 });
+    expect(setupMock).toHaveBeenNthCalledWith(2, { delay: 20 });
+  });
+
+  it('merges the derived delay into an explicit setup() call', () => {
+    setPace(500);
+
+    userEvent.setup();
+
+    expect(setupMock).toHaveBeenCalledWith({ delay: 50 });
+  });
+
+  it('lets a caller-supplied delay win over the derived one', () => {
+    setPace(500);
+
+    userEvent.setup({ delay: 5 });
+
+    expect(setupMock).toHaveBeenCalledWith(expect.objectContaining({ delay: 5 }));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest --run src/tests/proxies/userEventPacing.spec.ts -t "key delay"`
+Expected: FAIL, `setupMock` is never called with a delay.
+
+- [ ] **Step 3: Add the cached paced instance**
+
+In `src/proxies/userEvent.ts`, add the import and the cache above `createLoggedProxy`:
+
+```ts
+import { pace, getKeyDelay, getPaceGeneration } from '../pace';
+```
+
+```ts
+// Keyed on the pace generation, not on the delay. A plain `cached ??= ...`
+// would keep a stale delay forever, and keying on the delay alone would miss
+// the case where the same value is set twice.
+let cachedPaced: { generation: number; user: any } | null = null;
+
+/**
+ * The implementation to call for `prop`.
+ *
+ * When paced, this is a user-event setup instance carrying the derived delay.
+ * user-event applies `delay` at config level, so one instance covers every
+ * method uniformly, including `clear`, which takes no options via the direct
+ * API. Returns null when pacing is off so the direct API is used untouched.
+ */
+function pacedImpl(prop: string | symbol): ((...args: any[]) => any) | null {
+  const delay = getKeyDelay();
+  if (!delay) {
+    cachedPaced = null;
+    return null;
+  }
+
+  const generation = getPaceGeneration();
+  if (!cachedPaced || cachedPaced.generation !== generation) {
+    cachedPaced = { generation, user: userEventLib.setup({ delay }) };
+  }
+
+  const fn = cachedPaced.user[prop];
+  return typeof fn === 'function' ? fn.bind(cachedPaced.user) : null;
+}
+```
+
+- [ ] **Step 4: Use it in the action paths**
+
+In `src/proxies/userEvent.ts`, only in the **root** proxy (`prefix === 'userEvent'`), pick the implementation at call time. In the `type`, `clear`, `keyboard` and generic wrappers, replace the non-fallback `orig(...args)` call with:
+
+```ts
+        const impl = prefix === 'userEvent' ? pacedImpl(prop) ?? orig : orig;
+        const result = await impl(...args);
+```
+
+Do not route the fallback paths. They bypass user-event entirely and write the value with a native setter, so there is no delay to apply.
+
+Do not route instance proxies (`prefix === 'userEvent.instance'`). Those already carry their own config from the `setup()` call that created them, and re-routing would discard it.
+
+- [ ] **Step 5: Merge the delay into explicit setup() calls**
+
+In the `setup` branch of `createLoggedProxy`, spread the caller's options last so an explicit `delay` wins:
+
+```ts
+      if (prop === 'setup') {
+        return (...args: any[]) => {
+          const delay = getKeyDelay();
+          const instance = delay
+            ? orig({ delay, ...(args[0] || {}) })
+            : orig(...args);
+          return createLoggedProxy(instance, `${prefix}.instance`);
+        };
+      }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest --run src/tests/proxies/userEventPacing.spec.ts`
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npx vitest --run`
+Expected: PASS. `src/tests/proxies/userEvent.spec.ts` uses the real library with pacing off, so it must be untouched and green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/proxies/userEvent.ts src/tests/proxies/userEventPacing.spec.ts
+git commit -m "feat(pace): space keystrokes via a cached user-event instance"
+```
+
+---
+
+## Manual verification
+
+The automated tests mock the user-event library, so one real check is worth doing in `examples/twd-test-app`, which imports directly from source:
+
+```bash
+cd examples/twd-test-app
+npm run dev
+```
+
+In the browser console:
+
+```js
+window.__twdSetPace(600)
+```
+
+Then run a test from the sidebar. Expected: visible pauses after each click, and text appearing character by character rather than all at once. Then `window.__twdSetPace(0)` and re-run: the test should run at full speed again with no pauses.
+
+## Behavior to accept, not work around
+
+The direct API builds a fresh `System` per call, while a setup instance shares pointer and keyboard state across calls, so the pointer stays where the previous action left it. That is the library's own recommended usage and arguably more realistic. It applies only when pacing is on, which only happens inside a recorded run, and recorded runs are already documented as not a substitute for a CI run.
+
+## Not in this plan
+
+The twd-cli side (a `record.pace` config key, a `--record-pace` flag, and the `page.evaluate` call that drives `window.__twdSetPace`) is a separate plan in that repo. This plan is independently testable via the browser console, as described above.
+
+Overlays are out of scope. See the "Overlays, considered and dropped" section of the spec for the constraints found, should they ever be revisited.

--- a/src/commands/visit.ts
+++ b/src/commands/visit.ts
@@ -1,5 +1,6 @@
 import { wait } from '../utils/wait';
 import { log } from '../utils/log';
+import { pace } from '../pace';
 
 const DELAY = 100;
 
@@ -17,4 +18,5 @@ export const visit = async (url: string, reload?: boolean): Promise<void> => {
   window.history.pushState({}, '', url);
   window.dispatchEvent(new PopStateEvent('popstate'));
   await wait(DELAY);
+  await pace();
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,7 @@ declare global {
   interface Window {
     __testRunner?: any;
     __TWD_STATE__?: any;
+    __twdSetPace?: (ms: unknown) => number;
     __TWD_MOCK_STATE__?: any;
     __twdCollectMock?: (mock: {
       alias: string;

--- a/src/pace.ts
+++ b/src/pace.ts
@@ -1,0 +1,57 @@
+import { wait } from './utils/wait';
+
+const MAX_PACE_MS = 5000;
+const MAX_KEY_DELAY_MS = 60;
+
+let paceMs = 0;
+let keyDelayMs = 0;
+let generation = 0;
+
+/**
+ * Sets the delay inserted after each paced command, in milliseconds.
+ *
+ * This is a tooling hook for twd-cli, deliberately not exported from
+ * src/index.ts. Pacing is only ever wanted inside a recorded run, and a public
+ * API method could be left behind in a spec file, silently slowing every future
+ * CI run with no obvious cause.
+ *
+ * Invalid input disables pacing rather than throwing, and large values are
+ * clamped, so a typo cannot hang a run.
+ *
+ * @returns the pace actually applied
+ */
+export const setPace = (ms: unknown): number => {
+  paceMs = typeof ms === 'number' && Number.isFinite(ms) && ms > 0 ? Math.min(ms, MAX_PACE_MS) : 0;
+  keyDelayMs = paceMs ? Math.min(MAX_KEY_DELAY_MS, Math.round(paceMs / 10)) : 0;
+  generation += 1;
+  return paceMs;
+};
+
+/**
+ * The per-keystroke delay derived from the pace.
+ *
+ * A separate, much smaller scale is unavoidable: user-event applies `delay`
+ * uniformly, so reusing the pace itself would put half a second between every
+ * character.
+ */
+export const getKeyDelay = (): number => keyDelayMs;
+
+/**
+ * Bumped by every setPace call, so consumers holding derived state can tell it
+ * is stale. Keying such a cache on the delay alone is not enough: setting the
+ * same value twice must still invalidate.
+ */
+export const getPaceGeneration = (): number => generation;
+
+/**
+ * Returns undefined synchronously when pacing is off, so a normal run allocates
+ * no promise and schedules no timer. Do not make this an async function.
+ */
+export const pace = (): void | Promise<void> => {
+  if (!paceMs) return;
+  return wait(paceMs);
+};
+
+if (typeof window !== 'undefined') {
+  window.__twdSetPace = setPace;
+}

--- a/src/proxies/userEvent.ts
+++ b/src/proxies/userEvent.ts
@@ -1,7 +1,7 @@
 import userEventLib from '@testing-library/user-event';
 import { log } from '../utils/log';
 import { eventsMessage } from './eventsMessage';
-import { pace } from '../pace';
+import { pace, getKeyDelay, getPaceGeneration } from '../pace';
 
 type UserEvent = typeof userEventLib;
 
@@ -113,6 +113,39 @@ async function logAndPace(prefix: string, prop: string | symbol, args: any[]) {
   await pace();
 }
 
+// Keyed on the pace generation, not on the delay. A plain `cached ??= ...`
+// would keep a stale delay forever, and keying on the delay alone would miss
+// the case where the same value is set twice.
+let cachedPaced: { generation: number; user: any } | null = null;
+
+/**
+ * The implementation to call for `prop`.
+ *
+ * When paced, this is a user-event setup instance carrying the derived delay.
+ * user-event applies `delay` at config level, in wrapAndBindImpl after every
+ * API method as well as between keystrokes and pointer actions, so one instance
+ * covers every method uniformly. That includes `clear`, which is the one direct
+ * API method taking no options at all.
+ *
+ * Returns null when pacing is off, so a normal run uses the direct API
+ * untouched and builds no instance.
+ */
+function pacedImpl(prop: string | symbol): ((...args: any[]) => any) | null {
+  const delay = getKeyDelay();
+  if (!delay) {
+    cachedPaced = null;
+    return null;
+  }
+
+  const generation = getPaceGeneration();
+  if (!cachedPaced || cachedPaced.generation !== generation) {
+    cachedPaced = { generation, user: userEventLib.setup({ delay }) };
+  }
+
+  const fn = cachedPaced.user[prop];
+  return typeof fn === 'function' ? fn.bind(cachedPaced.user) : null;
+}
+
 function createLoggedProxy(obj: any, prefix = 'userEvent') {
   return new Proxy(obj, {
     get(target, prop, receiver) {
@@ -122,7 +155,9 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
       // Special handling for setup
       if (prop === 'setup') {
         return (...args: any[]) => {
-          const instance = orig(...args);
+          // Spread the caller's options last so an explicit delay wins.
+          const delay = getKeyDelay();
+          const instance = delay ? orig({ delay, ...(args[0] || {}) }) : orig(...args);
           // Proxy the returned instance
           return createLoggedProxy(instance, `${prefix}.instance`);
         };
@@ -136,7 +171,8 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
             await logAndPace(prefix, prop, args);
             return;
           }
-          const result = await orig(...args);
+          const impl = prefix === 'userEvent' ? (pacedImpl(prop) ?? orig) : orig;
+          const result = await impl(...args);
           await logAndPace(prefix, prop, args);
           return result;
         };
@@ -150,7 +186,8 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
             await logAndPace(prefix, prop, args);
             return;
           }
-          const result = await orig(...args);
+          const impl = prefix === 'userEvent' ? (pacedImpl(prop) ?? orig) : orig;
+          const result = await impl(...args);
           await logAndPace(prefix, prop, args);
           return result;
         };
@@ -217,14 +254,16 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
             await logAndPace(prefix, prop, args);
             return;
           }
-          const result = await orig(...args);
+          const impl = prefix === 'userEvent' ? (pacedImpl(prop) ?? orig) : orig;
+          const result = await impl(...args);
           await logAndPace(prefix, prop, args);
           return result;
         };
       }
 
       return async (...args: any[]) => {
-        const result = await orig(...args);
+        const impl = prefix === 'userEvent' ? (pacedImpl(prop) ?? orig) : orig;
+        const result = await impl(...args);
         await logAndPace(prefix, prop, args);
         return result;
       };

--- a/src/proxies/userEvent.ts
+++ b/src/proxies/userEvent.ts
@@ -1,6 +1,7 @@
 import userEventLib from '@testing-library/user-event';
 import { log } from '../utils/log';
 import { eventsMessage } from './eventsMessage';
+import { pace } from '../pace';
 
 type UserEvent = typeof userEventLib;
 
@@ -103,6 +104,15 @@ function clearFallback(element: HTMLElement) {
   typingFallback(element, '');
 }
 
+/**
+ * Logs the command and then holds, so a recorded run shows the result of the
+ * action before moving on. `pace()` is a no-op when pacing is off.
+ */
+async function logAndPace(prefix: string, prop: string | symbol, args: any[]) {
+  log(eventsMessage(prefix, prop, args));
+  await pace();
+}
+
 function createLoggedProxy(obj: any, prefix = 'userEvent') {
   return new Proxy(obj, {
     get(target, prop, receiver) {
@@ -123,11 +133,11 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
         return async (...args: any[]) => {
           if (document.visibilityState === 'hidden' || !document.hasFocus()) {
             typingFallback(args[0], args[1]);
-            log(eventsMessage(prefix, prop, args));
+            await logAndPace(prefix, prop, args);
             return;
           }
           const result = await orig(...args);
-          log(eventsMessage(prefix, prop, args));
+          await logAndPace(prefix, prop, args);
           return result;
         };
       }
@@ -137,11 +147,11 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
         return async (...args: any[]) => {
           if (document.visibilityState === 'hidden' || !document.hasFocus()) {
             clearFallback(args[0]);
-            log(eventsMessage(prefix, prop, args));
+            await logAndPace(prefix, prop, args);
             return;
           }
           const result = await orig(...args);
-          log(eventsMessage(prefix, prop, args));
+          await logAndPace(prefix, prop, args);
           return result;
         };
       }
@@ -204,18 +214,18 @@ function createLoggedProxy(obj: any, prefix = 'userEvent') {
             }
 
             flushText();
-            log(eventsMessage(prefix, prop, args));
+            await logAndPace(prefix, prop, args);
             return;
           }
           const result = await orig(...args);
-          log(eventsMessage(prefix, prop, args));
+          await logAndPace(prefix, prop, args);
           return result;
         };
       }
 
       return async (...args: any[]) => {
         const result = await orig(...args);
-        log(eventsMessage(prefix, prop, args));
+        await logAndPace(prefix, prop, args);
         return result;
       };
     },

--- a/src/tests/pace.spec.ts
+++ b/src/tests/pace.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setPace, getKeyDelay, getPaceGeneration, pace } from '../pace';
+
+describe('setPace', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  it('stores and returns a positive pace', () => {
+    expect(setPace(500)).toBe(500);
+  });
+
+  it('clamps to the 5000ms ceiling so a typo cannot hang a run', () => {
+    expect(setPace(99999)).toBe(5000);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['a negative number', -100],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['undefined', undefined],
+    ['null', null],
+    ['a string', '500'],
+    ['an object', {}],
+  ])('treats %s as disabled rather than throwing', (_label, input) => {
+    expect(setPace(input)).toBe(0);
+    expect(getKeyDelay()).toBe(0);
+  });
+});
+
+describe('getKeyDelay', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  it.each([
+    [200, 20],
+    [500, 50],
+    [600, 60],
+    [2000, 60],
+  ])('derives %ims pace into a %ims key delay', (paceMs, expected) => {
+    setPace(paceMs);
+    expect(getKeyDelay()).toBe(expected);
+  });
+});
+
+describe('pace', () => {
+  afterEach(() => {
+    setPace(0);
+    vi.useRealTimers();
+  });
+
+  // This is the zero-cost invariant. It fails if someone later makes `pace` an
+  // `async` function, which would silently allocate a promise on every command.
+  it('returns undefined and not a Promise when disabled', () => {
+    setPace(0);
+    const result = pace();
+    expect(result).toBeUndefined();
+    expect(result).not.toBeInstanceOf(Promise);
+  });
+
+  it('returns a Promise when enabled', () => {
+    setPace(500);
+    expect(pace()).toBeInstanceOf(Promise);
+  });
+
+  it('resolves only after the configured delay', async () => {
+    vi.useFakeTimers();
+    setPace(500);
+    let resolved = false;
+    const pending = Promise.resolve(pace()).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(resolved).toBe(true);
+  });
+});
+
+describe('getPaceGeneration', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  // The userEvent proxy caches a user-event instance built from the key delay.
+  // Keying that cache on the delay alone is not enough, because setting the
+  // same value twice must still invalidate. The generation makes it exact.
+  it('increments on every setPace call, including a repeat of the same value', () => {
+    const start = getPaceGeneration();
+
+    setPace(500);
+    expect(getPaceGeneration()).toBe(start + 1);
+
+    setPace(500);
+    expect(getPaceGeneration()).toBe(start + 2);
+
+    setPace(0);
+    expect(getPaceGeneration()).toBe(start + 3);
+  });
+});
+
+describe('the window hook', () => {
+  afterEach(() => {
+    setPace(0);
+  });
+
+  it('exposes setPace as window.__twdSetPace', () => {
+    expect(window.__twdSetPace).toBe(setPace);
+    expect(window.__twdSetPace!(300)).toBe(300);
+  });
+});
+
+describe('public API surface', () => {
+  it('does not leak setPace out of the package entry point', async () => {
+    const publicApi = await import('../index');
+    expect(Object.keys(publicApi)).not.toContain('setPace');
+    expect(Object.keys(publicApi)).not.toContain('pace');
+  });
+
+  it('does not put setPace on the twd object', async () => {
+    const { twd } = await import('../twd');
+    expect('setPace' in twd).toBe(false);
+  });
+});

--- a/src/tests/proxies/userEventPacing.spec.ts
+++ b/src/tests/proxies/userEventPacing.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// vi.mock factories are hoisted above module-level consts, so the doubles have
+// to be created inside vi.hoisted for the factory to see them.
+const { instanceApi, directApi, setupMock } = vi.hoisted(() => {
+  const makeApi = () => ({
+    click: vi.fn().mockResolvedValue(undefined),
+    type: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn().mockResolvedValue(undefined),
+    keyboard: vi.fn().mockResolvedValue(undefined),
+  });
+  const instance = makeApi();
+  return {
+    instanceApi: instance,
+    directApi: makeApi(),
+    setupMock: vi.fn(() => instance),
+  };
+});
+
+vi.mock('@testing-library/user-event', () => ({
+  default: { ...directApi, setup: setupMock },
+}));
+
+vi.mock('../../pace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../pace')>();
+  return { ...actual, pace: vi.fn() };
+});
+
+import { userEvent } from '../../proxies/userEvent';
+import { setPace, pace } from '../../pace';
+
+describe('userEvent pacing', () => {
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPace(0);
+    input = document.createElement('input');
+    document.body.appendChild(input);
+  });
+
+  afterEach(() => {
+    setPace(0);
+    input.remove();
+  });
+
+  it('paces after an interaction', async () => {
+    await userEvent.click(input);
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('paces after typing', async () => {
+    await userEvent.type(input, 'hello');
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('paces after clearing', async () => {
+    await userEvent.clear(input);
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('paces after keyboard input', async () => {
+    input.focus();
+    await userEvent.keyboard('abc');
+    expect(pace).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not pace on setup, which performs no action', () => {
+    userEvent.setup();
+    expect(pace).not.toHaveBeenCalled();
+  });
+
+  it('calls through to the real library rather than swallowing the action', async () => {
+    await userEvent.click(input);
+
+    expect(directApi.click).toHaveBeenCalledWith(input);
+    expect(instanceApi.click).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/proxies/userEventPacing.spec.ts
+++ b/src/tests/proxies/userEventPacing.spec.ts
@@ -77,3 +77,75 @@ describe('userEvent pacing', () => {
     expect(instanceApi.click).not.toHaveBeenCalled();
   });
 });
+
+describe('userEvent key delay', () => {
+  let input: HTMLInputElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPace(0);
+    input = document.createElement('input');
+    document.body.appendChild(input);
+  });
+
+  afterEach(() => {
+    setPace(0);
+    input.remove();
+  });
+
+  it('uses the direct API and creates no instance when pacing is off', async () => {
+    await userEvent.click(input);
+
+    expect(setupMock).not.toHaveBeenCalled();
+    expect(directApi.click).toHaveBeenCalledTimes(1);
+    expect(instanceApi.click).not.toHaveBeenCalled();
+  });
+
+  it('routes through a setup instance carrying the derived delay when paced', async () => {
+    setPace(500);
+
+    await userEvent.click(input);
+
+    expect(setupMock).toHaveBeenCalledWith({ delay: 50 });
+    expect(instanceApi.click).toHaveBeenCalledTimes(1);
+    expect(directApi.click).not.toHaveBeenCalled();
+  });
+
+  it('reuses the cached instance across calls at the same pace', async () => {
+    setPace(500);
+
+    await userEvent.click(input);
+    await userEvent.click(input);
+
+    expect(setupMock).toHaveBeenCalledTimes(1);
+  });
+
+  // A plain `instance ??= setup(...)` would keep the stale 50ms delay here.
+  it('rebuilds the instance when the pace changes', async () => {
+    setPace(500);
+    await userEvent.click(input);
+
+    setPace(200);
+    await userEvent.click(input);
+
+    expect(setupMock).toHaveBeenCalledTimes(2);
+    expect(setupMock).toHaveBeenNthCalledWith(1, { delay: 50 });
+    expect(setupMock).toHaveBeenNthCalledWith(2, { delay: 20 });
+  });
+
+  it('merges the derived delay into an explicit setup() call', () => {
+    setPace(500);
+
+    userEvent.setup();
+
+    expect(setupMock).toHaveBeenCalledWith({ delay: 50 });
+  });
+
+  it('lets a caller-supplied delay win over the derived one', () => {
+    setPace(500);
+
+    userEvent.setup({ delay: 5 });
+
+    expect(setupMock).toHaveBeenCalledWith(expect.objectContaining({ delay: 5 }));
+  });
+});


### PR DESCRIPTION
Lets a recorded twd-cli run space out its own commands, so the video is watchable instead of a blur.

This is the twd-js half. It does nothing on its own until twd-cli drives it, which is a separate PR in that repo.

## Why not just slow the video down

twd-cli already has `record.speed`, an ffmpeg `setpts` filter applied after recording. It stretches the same frames over a longer timeline, so the effective frame rate falls in proportion. Measured on identical page activity:

| speed | duration | effective fps |
|---|---|---|
| `1` | 1.00s | 30 |
| `0.5` | 1.90s | 15.3 |
| `0.25` | 3.90s | 7.7 |

It also slows the dead air exactly as much as the interesting moments. TWD owns its own in-page command loop, so it can pace the execution instead and keep full frame rate.

## How it is enabled

`window.__twdSetPace(ms)`, registered alongside the existing `__TWD_STATE__` and `__testRunner` globals.

Deliberately **not** a public `twd.setPace()`. A documented API method can be left behind in a spec file, and every future CI run would then be slower with no obvious cause. There is a test asserting it never leaks out of `src/index.ts` or onto the `twd` object.

## One number, two scales

The caller passes one number. The keystroke delay is derived from it and clamped at 60ms, because user-event applies `delay` uniformly and reusing the pace itself would put half a second between every character.

| `setPace(ms)` | between actions | per keystroke |
|---|---|---|
| `200` | 200ms | 20ms |
| `500` | 500ms | 50ms |
| `2000` | 2000ms | 60ms (clamped) |

## What is paced, and what is not

Paced: `userEvent.*` interactions and `twd.visit`. Both are already async, so nothing became async that was not.

Not paced, on purpose: `should()` and `twd.setInputValue()` are synchronous chainables and pacing them would be a breaking change; the `screenDom` proxy is a pass-through with no uniform hook; queries do not change the page, so a pause after one is dead air with no highlight to show.

## Keystroke spacing

user-event applies `delay` at config level, in `wrapAndBindImpl` after every API method as well as between keystrokes, pointer actions and option selections. So when paced the proxy routes through a cached `setup({ delay })` instance rather than merging options per call. That covers every method uniformly and sidesteps `clear(element)` being the one direct API method that takes no options.

The cache is keyed on a pace generation counter, not on the delay, so setting the same value twice still invalidates.

**Behavior note:** the direct API builds a fresh `System` per call while a setup instance shares pointer state across calls. That is the library's recommended usage and arguably more realistic, and it only applies when pacing is on, which only happens inside a recorded run.

## Normal runs are untouched

`pace()` returns `undefined` synchronously when disabled: no promise allocated, no timer scheduled, no setup instance built. There is a test pinning that it returns `undefined` and not a Promise, which fails loudly if anyone later makes it an `async` function.

## Verification

439 tests passing, up from 406. `tsc` unchanged at its 4 pre-existing errors, none in the touched files.

Driven end to end against `examples/twd-test-app` with Puppeteer:

```
window.__twdSetPace is a function
pace 0   -> applied=0    run took 120ms
pace 600 -> applied=600  run took 718ms   (6.0x slower)
```

120 + 600 = 720 against a measured 718, so the hold lands exactly once per action and `setPace(0)` restores full speed. Manually confirmed at 200 and 500, which both read well.

## Included docs

`specs/2026-07-28-twd-js-command-pacing-design.md` is the design and `specs/2026-07-28-twd-js-command-pacing-plan.md` is the plan. The earlier overlay draft is kept but marked superseded: overlays are dropped for v1, since the only reason to pause after a query is to highlight what it found.

No public documentation is added, because `__twdSetPace` is deliberately not public API.

## Next

twd-cli gains a `record.pace` key and a `--record-pace <ms>` flag that calls this. That needs a twd-js release first, since the global does not exist until then.