### PR TITLE
docs: document twd-cli sharding and the missing CI config options

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -117,6 +117,7 @@ export default defineConfig({
           { text: 'Module Mocking', link: '/module-mocking' },
           { text: 'Theming', link: '/theming' },
           { text: 'CI Execution', link: '/ci-execution' },
+          { text: 'Sharding (beta)', link: '/sharding' },
           { text: 'Recording Runs', link: '/recording' },
           { text: 'Coverage', link: '/coverage' },
           { text: 'AI Integration', link: '/ai-overview' },

--- a/docs/ci-execution.md
+++ b/docs/ci-execution.md
@@ -48,6 +48,9 @@ Create `twd.config.json` in your repo to customize the runner:
   "headless": true,
   "puppeteerArgs": ["--no-sandbox", "--disable-setuid-sandbox"],
   "retryCount": 2,
+  "protocolTimeout": 300000,
+  "maxFailures": 10,
+  "chunkSize": 10,
   "contracts": [],
   "contractReportPath": ".twd/contract-report.md"
 }
@@ -63,8 +66,45 @@ Create `twd.config.json` in your repo to customize the runner:
 | `headless` | boolean | `true` | Run Chrome in headless mode |
 | `puppeteerArgs` | string[] | `["--no-sandbox", "--disable-setuid-sandbox"]` | Extra arguments for Puppeteer |
 | `retryCount` | number | `2` | Number of times to attempt each test before reporting failure. Default is 2 (one normal attempt + one retry). Set to 1 to disable retries. |
+| `protocolTimeout` | number | `300000` | Puppeteer CDP `protocolTimeout` in ms (5 min). Tests run in chunks, so this bounds a **single chunk's browser call**, not the entire run. Raise it (e.g. `600000`) for slow CI or if individual chunks hang. `0` means no timeout. |
+| `maxFailures` | number | `10` | Stop the run once this many tests have failed in total. The CLI prints the results gathered so far and exits non-zero. Set `0` to disable and always run every test. Note this limit is **per shard** when [sharding](/sharding). |
+| `chunkSize` | number | `10` | How many tests run per browser call. Smaller values make the failure limit and timeouts more granular (less work lost if one chunk hangs), larger values reduce overhead. `0` runs everything in one call. |
 | `contracts` | object[] | `[]` | OpenAPI contract validation specs. See [Contract Testing](/contract-testing) |
 | `contractReportPath` | string | — | Path to write a markdown report for CI/PR integration |
+| `record` | object | see [Recording Runs](/recording) | Video recording settings |
+
+## Filtering tests
+
+Run only a subset of tests with the repeatable `--test` flag. Matching is
+**case-insensitive** and matches a **substring** of each test's full
+`"Suite > test name"` path:
+
+```bash
+# Every test whose name contains "shows error"
+npx twd-cli run --test "shows error"
+
+# Because matching uses the full "suite > test" path, passing a describe name
+# runs every test inside that describe block:
+npx twd-cli run --test "Login"
+
+# Multiple --test flags are combined with OR (a test runs if it matches any):
+npx twd-cli run --test "Login" --test "Signup"
+```
+
+Two things to know:
+
+- If no test matches any filter, the run exits with code `1` and prints
+  `No tests matched filter(s): ...`, so a typo will not silently look like a pass.
+- Code coverage collection is skipped while a `--test` filter is active, since a
+  filtered run is a partial (debug) run.
+
+`--test` and `--shard` compose. Filters resolve first, then the filtered list is
+sharded. See [Sharding](/sharding).
+
+::: tip
+`twd-relay` accepts the same `--test` flag for driving a run from an AI agent.
+See [AI Remote Testing](/ai-remote-testing).
+:::
 
 ## GitHub Action (Recommended)
 
@@ -117,6 +157,9 @@ jobs:
 |-------|---------|-------------|
 | `working-directory` | `.` | Directory where `twd.config.json` lives |
 | `contract-report` | `false` | Post contract validation summary as a PR comment |
+| `shard` | (empty) | Run one shard of the suite, as `<index>/<total>` (e.g. `2/4`). Leave empty to run everything in one job. See [Sharding](/sharding) |
+| `report-dir` | `.twd/run` | Where the shard report is written. Only used when `shard` is set |
+| `upload-report` | `true` | Upload the shard report as an artifact named `twd-run-<index>`, the layout `twd-cli merge` expects. Only used when `shard` is set |
 
 ### With code coverage
 
@@ -226,6 +269,7 @@ Run your **full suite on Chromium with `twd-cli`** (coverage, contracts, retries
 
 ## Next Steps
 
+- [Sharding](/sharding): Split a long run across parallel CI jobs and merge the reports (beta)
 - [Recording Runs](/recording): Record a run to video, paced so it is watchable in a pull request
 - [Contract Testing](/contract-testing): Validate your API mocks against OpenAPI specs
 - [Code Coverage](/coverage): Learn how to collect and report code coverage with TWD

--- a/docs/contract-testing-setup.md
+++ b/docs/contract-testing-setup.md
@@ -108,8 +108,33 @@ Failed validations are included in a collapsible details section with a link to 
 
 See [CI Execution](/ci-execution#github-action-recommended) for the full workflow setup.
 
+### With a sharded run
+
+A [sharded run](/sharding) deliberately writes no contract markdown per shard,
+because each would overwrite the others with a fraction of the mocks.
+`twd-cli merge` writes it instead, so the PR comment step belongs in the merge
+job rather than in the shard jobs:
+
+```yaml
+  merge:
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # ...checkout, npm ci, download the shard artifacts, then:
+      - name: Merge the shard reports
+        run: npx twd-cli merge .twd/shards
+
+      - name: Post contract report to PR
+        if: github.event_name == 'pull_request' && hashFiles('.twd/contract-report.md') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment "${{ github.event.pull_request.number }}" --body-file .twd/contract-report.md
+```
+
 ## Next Steps
 
 - Run contract tests in CI with the [GitHub Action](/ci-execution#github-action-recommended)
 - Learn how to create mocks with [API Mocking](/api-mocking)
 - Collect [Code Coverage](/coverage) alongside contract validation
+- Split a long run across parallel jobs with [Sharding](/sharding)

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -38,6 +38,7 @@ Key features:
 - [Framework Integration](https://twd.dev/frameworks): React, Vue, Angular, Solid, Astro, React Router, Nuxt, CRA, HTMX, and vanilla JS setup
 - [Testing Library](https://twd.dev/testing-library): Testing Library integration and selectors
 - [CI Execution](https://twd.dev/ci-execution): twd-cli setup, Puppeteer, GitHub Actions
+- [Sharding](https://twd.dev/sharding): Split a long run across parallel CI jobs with --shard and twd-cli merge (beta)
 - [Coverage](https://twd.dev/coverage): Code coverage reporting
 - [AI Integration](https://twd.dev/ai-overview): Connecting AI agents — relay, Claude plugin, skills, context prompts
 - [Contract Testing Setup](https://twd.dev/contract-testing-setup): OpenAPI validation setup, contract options, supported validations, PR reports

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -1,0 +1,227 @@
+---
+title: Sharding
+description: Split a long TWD test run across parallel CI jobs with twd-cli --shard, then merge the shard reports into one summary
+---
+
+# Sharding across CI jobs
+
+::: warning Beta
+Sharding is new and marked beta on purpose. It is strictly additive: a run
+without `--shard` behaves exactly as it did before, writes the same files, and
+exits the same way, so enabling it cannot affect your existing pipeline.
+
+What may still change is **how tests are assigned to shards**. Today each shard
+takes every nth test from the discovered list, and a future release is likely to
+group by top-level `describe` instead, so a suite always stays in one shard. Do
+not build anything that depends on *which* tests land in a given shard.
+Everything else (the flags, the report files, `merge`'s output and exit code) is
+stable.
+:::
+
+A single run walks the whole suite in one browser. Sharding splits it across
+parallel CI jobs instead, then joins the results back into one report.
+
+```bash
+npx twd-cli run --shard 2/4     # "I am job 2 of 4"
+npx twd-cli merge .twd/shards   # join the reports, decide the exit code
+```
+
+Requires `twd-cli` 1.5.0 or newer.
+
+The `4` is how many jobs you are running, **not** how many tests exist. You never
+need to know the test count. Each shard boots its own browser, discovers the
+whole suite exactly as a normal run does, and keeps every 4th test. Add tests and
+the same 4 jobs just split more of them.
+
+Each shard writes `run.json` and `coverage.json` to `./.twd/run` (change it with
+`--report-dir`). `merge` reads the downloaded shard directories, combines test
+results, coverage and contract validation, prints one summary, and exits non-zero
+if anything failed anywhere.
+
+## A complete workflow
+
+This runs as-is. The bundled action installs Chrome, runs the shard, and uploads
+its report under the name `merge` expects.
+
+```yaml
+name: TWD tests (sharded)
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      # Without this, the first red shard cancels its siblings and the merge job
+      # sees gaps it cannot tell apart from a shard that crashed.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install mock service worker
+        run: npx twd-js init public --save
+
+      - name: Start the dev server
+        run: |
+          nohup npm run dev > dev.log 2>&1 &
+          npx wait-on http://localhost:5173 --timeout 60000
+
+      - name: Run this shard
+        uses: BRIKEV/twd-cli/.github/actions/run@main
+        with:
+          shard: ${{ matrix.shard }}/4
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [test]
+    # Runs even though a shard job may have exited 1. Without this a red shard
+    # short-circuits the workflow and the merged summary never prints.
+    if: ${{ !cancelled() }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: twd-run-*
+          path: .twd/shards
+
+      - name: Merge the shard reports
+        run: npx twd-cli merge .twd/shards
+```
+
+`merge` owns the final exit code. It fails if any test failed in any shard, if a
+contract was violated in `error` mode, or if a shard report is missing entirely.
+
+## Without the bundled action
+
+If you drive the CLI directly, you own the two steps the action was doing for
+you: installing Chrome, and uploading the report with `if: always()`.
+
+```yaml
+      - run: npx puppeteer browsers install chrome
+      - run: npx twd-cli run --shard ${{ matrix.shard }}/4
+      - uses: actions/upload-artifact@v4
+        # A red shard must still upload, or merge cannot tell "this shard failed"
+        # from "this shard never ran".
+        if: always()
+        with:
+          name: twd-run-${{ matrix.shard }}
+          path: .twd/run
+          if-no-files-found: error
+```
+
+## Commands and flags
+
+| Flag | Command | Default | Description |
+|------|---------|---------|-------------|
+| `--shard <i>/<n>` | `run` | off | Run shard `i` of `n`. A malformed spec throws rather than silently running zero tests |
+| `--report-dir <path>` | `run` | `.twd/run` | Where this shard writes `run.json` and `coverage.json` |
+| `--out <path>` | `merge` | `.twd/merged-run.json` | Where the merged report is written |
+
+`twd-cli merge <dir>` takes the directory holding the downloaded shard reports as
+its first positional argument.
+
+## The three conditions that matter
+
+Each of these breaks a sharded run in a different way, and all three are easy to
+leave out:
+
+| Condition | Where | What breaks without it |
+|---|---|---|
+| `fail-fast: false` | the shard matrix | the first red shard cancels its siblings, and `merge` reports their reports as missing |
+| `if: always()` | the shard's artifact upload | a red shard uploads nothing, so `merge` cannot distinguish failure from a crash |
+| <code v-pre>if: ${{ !cancelled() }}</code> | the merge job | a red shard short-circuits the workflow and the merged summary never prints |
+
+## When sharding pays
+
+Sharding buys wall clock with compute. Every shard repeats the per-job setup
+(install, browser, dev server), and the merge job runs after all of them, so it
+only wins once test time dominates that fixed cost.
+
+Measured on a real suite of 256 browser tests:
+
+```
+Shards   Wall clock                            Runner time
+  1      █████████████████████████  12.6 min   baseline
+  2      ████████████████            8.1 min   +15%
+  4      █████████████               6.5 min   +47%
+         ├──────┤
+         ~4 min floor, no matter how far you shard
+```
+
+The takeaways:
+
+- **Most of the win is in the first split.** 1 to 2 shards saved 4.5 minutes.
+  2 to 4 saved only 1.6 more.
+- **There is a floor you cannot get under.** Setup runs in every shard and the
+  merge job runs after them all, so past four shards you pay a lot for seconds.
+- **Total compute goes up.** Runner time grew 15% at two shards and 47% at four.
+  If you are billed for runner minutes, or your runner concurrency is contended,
+  pick the smallest number of shards that gets you under your target.
+- **Short suites get slower.** The `twd-cli` project's own 71-test suite goes
+  from 25s in one job to 41s across two plus a merge. Under a couple of minutes,
+  do not shard.
+
+## Caveats
+
+- **Coverage.** Each shard writes its own `coverage.json`, and `merge` combines
+  them into `.nyc_output/out.json`, but only when the whole run is green. That
+  matches how a single run behaves. `merge` reports how many shards contributed.
+  See [Code Coverage](/coverage) for reporting on the merged output.
+- **Missing shards are an error.** If a shard job dies before uploading, `merge`
+  refuses and names the gap rather than silently reporting 3 of 4 shards as a
+  complete green run.
+- **Tests must register identically in every job.** Each shard fingerprints the
+  ordered list of `"suite > test"` paths it discovered and `merge` verifies they
+  match. Registering tests conditionally, behind a feature flag, a date, or
+  `Math.random()`, makes the fingerprints diverge and `merge` will say so. It
+  compares paths rather than internal test ids because `twd-js` assigns those at
+  registration time and they differ on every page load, so each shard's browser
+  sees its own.
+- **`maxFailures` is per shard.** Four shards at the default of 10 can reach 40
+  failures between them before all four bail.
+- **`--test` and `--shard` compose.** Filters resolve first, then the filtered
+  list is sharded. As with any filtered run, coverage is skipped.
+- **The contract report is written by `merge`, not per shard.** Each shard would
+  otherwise overwrite the others with a fraction of the mocks, so the PR comment
+  step belongs in the merge job. See
+  [Contract Testing Setup](/contract-testing-setup#pr-reports).
+- **Recording** produces one clip per shard. They are not concatenated.
+- **A missing shard leaves no merged report on disk.** `merge` throws before it
+  writes `.twd/merged-run.json`, so a CI step that uploads that path with
+  `if: always()` will find nothing when a shard is missing. The error message on
+  stderr is the diagnosis in that case.
+- **`record.filename` collides under sharding.** Only the *derived* recording
+  filename is per-shard. If `record.filename` is set explicitly in
+  `twd.config.json`, every shard writes to the same video path. Use the derived
+  name, or a per-shard `--record-dir`, when recording a sharded run. See
+  [Recording Runs](/recording).
+- **Assignment may change.** See the beta note at the top. Which tests land in
+  which shard is not part of the stable contract yet.
+
+## Next Steps
+
+- [CI Execution](/ci-execution): the single-job setup, config options, and the bundled action
+- [Recording Runs](/recording): capture a run to video for a pull request
+- [Contract Testing](/contract-testing): validate your API mocks against OpenAPI specs
+- [Code Coverage](/coverage): collect and report coverage

--- a/scripts/generate-llms-full.mjs
+++ b/scripts/generate-llms-full.mjs
@@ -18,7 +18,7 @@ const ORDER = [
   'getting-started.md', 'writing-tests.md', 'api-mocking.md', 'component-testing.md',
   'component-mocking.md',
   'module-mocking.md', 'frameworks.md', 'testing-library.md', 'ci-execution.md',
-  'coverage.md', 'ai-overview.md', 'contract-testing-setup.md', 'theming.md',
+  'sharding.md', 'coverage.md', 'ai-overview.md', 'contract-testing-setup.md', 'theming.md',
   'twd-ai/setup.md', 'twd-ai/writing-tests.md', 'twd-ai/ci-setup.md',
   'twd-ai/test-gaps.md', 'twd-ai/test-quality.md', 'twd-ai/flow-gallery.md',
   'claude-plugin.md', 'agents.md', 'ai-remote-testing.md',


### PR DESCRIPTION
## Description

`twd-cli` has shipped sharding since 1.5.0 (`--shard <i>/<n>` plus a `twd-cli merge` command), and none of it was on the docs site. Zero hits for `--shard`, `merge`, `report-dir` or `run.json` across `docs/`. While checking that, three config options and one CLI flag turned out to be missing too.

One of these was a live bug rather than just a gap: `recording.md` tells readers to "lower `chunkSize` or raise `protocolTimeout`", and neither key was defined anywhere on the site.

### New `/sharding` page

- The two commands, and the point that the `n` in `--shard 2/4` is your job count, not your test count
- A complete, runnable matrix workflow, plus the version for driving the CLI directly without the bundled action
- The three conditions that silently break a sharded run (`fail-fast: false`, `if: always()` on the upload, `if: ${{ !cancelled() }}` on the merge job), each of which fails differently
- Flags table for `--shard`, `--report-dir` and `merge --out`
- "When sharding pays": a chart of the measured numbers on a 256-test suite plus the takeaways, so the tradeoff is visible without reading algebra
- The caveats: `maxFailures` is per shard, coverage merges only when green, shards fingerprint their test list, the `record.filename` collision, and that shard assignment is still beta

### `ci-execution.md`

- Config table gained `protocolTimeout`, `maxFailures`, `chunkSize` and `record`
- Action Inputs table gained `shard`, `report-dir` and `upload-report`. It was listing 2 of the action's 5 inputs; defaults verified against `.github/actions/run/action.yml` in twd-cli
- New "Filtering tests" section for twd-cli's own `--test` flag, including that it exits 1 with `No tests matched filter(s)` so a typo cannot look like a pass, that coverage is skipped on a filtered run, and that it composes with `--shard`. `--test` was previously documented only for twd-relay

### `contract-testing-setup.md`

A sharded run writes no contract markdown per shard, because each would overwrite the others with a fraction of the mocks. `merge` writes it instead, so the PR comment step belongs in the merge job. That YAML lives here under `## PR Reports` rather than on the sharding page.

## Type of Change

- [x] Documentation update

## Testing

- [x] All existing tests pass
- [x] I have tested this change manually

### Test Details

Docs-only change, no test coverage applicable. Verified with `npm run docs:build`.

The build initially failed with `_ctx.cancelled is not a function`. VitePress wraps fenced code blocks in `v-pre` but not inline code spans, so the `` `if: ${{ !cancelled() }}` `` cell in the conditions table was being evaluated as a Vue expression. Fixed with `<code v-pre>`. Worth knowing for any future page that puts a GitHub Actions expression in a table or a sentence.

Also confirmed the new page lands in `llms-full.txt` between CI Execution and Coverage rather than being appended alphabetically at the end.

## Documentation

- [x] I have updated the documentation accordingly
- [x] The changes are reflected in the relevant documentation files

Registered in all three places a new page needs: the `config.mts` sidebar, the hand-maintained `docs/public/llms.txt` index, and the `ORDER` array in `scripts/generate-llms-full.mjs`.

## Follow-ups not included here

- `recording.md` is also absent from the `ORDER` array, so it gets appended at the end of `llms-full.txt` instead of sitting near the other CI pages. Pre-existing and unrelated to sharding.
- The matching Action Inputs table in the twd-cli README had the same 3 missing inputs. Fixed separately in BRIKEV/twd-cli.
