### PR TITLE
fix(matchLayout): load the snapshot plugin, and say where the layout moved

### DIFF
--- a/src/commands/layout/message.ts
+++ b/src/commands/layout/message.ts
@@ -1,11 +1,12 @@
 /**
- * Every string the user reads. The failure message says what moved and what to
- * do about it, and nothing else.
+ * Every string the user reads. The failure message says what moved, where, and
+ * what to do about it, and nothing else.
  *
- * The spike also printed the two hashes and an ASCII render of the grid. Both
- * are dropped: a user can do nothing with "00dd000020000018", and the ASCII
- * grid is a worse version of the picture that <name>.failed.png already shows
- * with the changed cells boxed in red.
+ * The hashes the spike printed stay out: nobody can act on
+ * "00dd000020000018". The diff map does not, because `<name>.failed.png` is a
+ * FILE and CI shows logs. Without the map a CI failure reports a count of rows
+ * and nothing else, which is not enough to tell an intended change from a
+ * regression without downloading an artifact.
  */
 import { COLS } from './grid';
 import { widthOf } from './snapFile';
@@ -16,8 +17,10 @@ export function layoutChangedMessage(input: {
   referenceSize: string;
   currentSize: string;
   rowsDiffering: number;
+  /** The diff rendered as text. Omitted when there is nothing to show. */
+  diff?: string;
 }): string {
-  const { name, dir, referenceSize, currentSize, rowsDiffering } = input;
+  const { name, dir, referenceSize, currentSize, rowsDiffering, diff } = input;
   const widthChanged = widthOf(referenceSize) !== widthOf(currentSize);
   const sizeChanged = referenceSize !== currentSize;
 
@@ -38,6 +41,15 @@ export function layoutChangedMessage(input: {
           `  The width changed, so the grid rescaled (cell = width/${COLS}) and the`,
           `  marked cells in the capture are indicative, not one to one.`,
           ``,
+        ]
+      : []),
+    ...(diff
+      ? [
+          `  X = changed    ~ = new row    # = filled    . = empty`,
+          diff
+            .split('\n')
+            .map((line) => (line ? `  ${line}` : ''))
+            .join('\n'),
         ]
       : []),
     `  Reference:  ${dir}/${name}.snap`,

--- a/src/commands/layout/rowDiff.ts
+++ b/src/commands/layout/rowDiff.ts
@@ -113,3 +113,69 @@ export function diffRows(baseline: Grid, current: Grid, tolerance = 1): RowOp[] 
 export function rowDistance(ops: RowOp[]): number {
   return ops.filter((op) => op.op !== 'same').length;
 }
+
+/**
+ * The diff as text, so a CI log can say WHERE the layout moved.
+ *
+ * `<name>.failed.png` shows the same thing better, but it is a file, and CI
+ * shows logs. Without this the only thing a CI failure reports is a count.
+ *
+ *   `X` changed cell   `~` row that is new   `#` filled   `.` empty
+ *
+ * Only rows near a change are printed. A landing page is 36 rows tall and
+ * dumping all of them is the noise this was accused of being; a diff prints
+ * hunks with context, not the whole file.
+ */
+const CONTEXT_ROWS = 2;
+
+export function renderRowDiff(ops: RowOp[], current: Grid): string {
+  const marks = new Map<number, string[]>();
+
+  for (const op of ops) {
+    if (op.op === 'removed' || op.op === 'same') continue;
+    if (op.op === 'added') {
+      marks.set(op.currentRow, new Array<string>(current.cols).fill('~'));
+      continue;
+    }
+    marks.set(
+      op.currentRow,
+      op.cells.map((changed) => (changed ? 'X' : '.')),
+    );
+  }
+
+  // A size-only change moves no row, and then there is nothing to point at.
+  if (marks.size === 0) return '';
+
+  // Rows with no mark still print their own bits: the surrounding structure is
+  // what makes the marked rows locatable on the page.
+  const bits = toBits(current);
+  const keep = new Set<number>();
+  for (const row of marks.keys()) {
+    for (let r = row - CONTEXT_ROWS; r <= row + CONTEXT_ROWS; r++) {
+      if (r >= 0 && r < current.rows) keep.add(r);
+    }
+  }
+
+  const lines: string[] = [];
+  let elided = 0;
+  const flush = () => {
+    if (elided) lines.push(`   ... ${elided} rows unchanged`);
+    elided = 0;
+  };
+
+  for (let row = 0; row < current.rows; row++) {
+    if (!keep.has(row)) {
+      elided++;
+      continue;
+    }
+    flush();
+    const marked = marks.get(row);
+    const cells = Array.from({ length: current.cols }, (_, col) =>
+      marked ? marked[col] : bits[row * current.cols + col] ? '#' : '.',
+    );
+    lines.push(`${String(row).padStart(3)}  ${cells.join(' ')}`);
+  }
+  flush();
+
+  return lines.length ? `${lines.join('\n')}\n` : '';
+}

--- a/src/commands/matchLayout.ts
+++ b/src/commands/matchLayout.ts
@@ -20,7 +20,7 @@ import {
   updatedMessage,
   viewportMismatchMessage,
 } from './layout/message';
-import { diffRows, rowDistance } from './layout/rowDiff';
+import { diffRows, renderRowDiff, rowDistance } from './layout/rowDiff';
 import { parse, serialize, widthOf } from './layout/snapFile';
 import { readSnapshot, writeSnapshot } from './layout/transport';
 
@@ -106,6 +106,7 @@ export async function matchLayout(el: HTMLElement, name: string): Promise<void> 
       referenceSize: previous.size,
       currentSize: capture.size,
       rowsDiffering,
+      diff: renderRowDiff(ops, capture.grid),
     }),
   );
 }

--- a/src/tests/commands/layout/message.spec.ts
+++ b/src/tests/commands/layout/message.spec.ts
@@ -52,7 +52,8 @@ describe('layoutChangedMessage', () => {
     expect(message).not.toContain('indicative, not one to one');
   });
 
-  it('never leaks the hash or an ASCII grid into the message', () => {
+  it('never leaks a hash into the message', () => {
+    // A hash is unactionable: nobody can do anything with "00dd000020000018".
     const message = layoutChangedMessage({
       ...base,
       referenceSize: '577x512',
@@ -61,7 +62,33 @@ describe('layoutChangedMessage', () => {
     });
 
     expect(message).not.toContain('expected  ');
-    expect(message).not.toMatch(/X = changed/);
+    expect(message).not.toMatch(/[0-9a-f]{16}/);
+  });
+
+  it('carries the diff map so a CI log says WHERE the layout moved', () => {
+    // The failure capture is a file. CI shows logs, not files, so without the
+    // map the only thing a CI run reports is a count of rows.
+    const message = layoutChangedMessage({
+      ...base,
+      referenceSize: '900x720',
+      currentSize: '900x720',
+      rowsDiffering: 1,
+      diff: '. . . .\n. X X .\n',
+    });
+
+    expect(message).toContain('X = changed');
+    expect(message).toContain('. X X .');
+  });
+
+  it('leaves the map out when there is none to show', () => {
+    const message = layoutChangedMessage({
+      ...base,
+      referenceSize: '900x720',
+      currentSize: '900x720',
+      rowsDiffering: 1,
+    });
+
+    expect(message).not.toContain('X = changed');
   });
 });
 

--- a/src/tests/commands/layout/rowDiff.spec.ts
+++ b/src/tests/commands/layout/rowDiff.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Grid } from '../../../commands/layout/grid';
-import { diffRows, rowDistance } from '../../../commands/layout/rowDiff';
+import { type RowOp, diffRows, renderRowDiff, rowDistance } from '../../../commands/layout/rowDiff';
 
 const fromRows = (rows: string[]): Grid => ({
   cells: rows.flatMap((row) => [...row].map((char) => (char === '#' ? 50 : 0))),
@@ -53,5 +53,74 @@ describe('diffRows', () => {
       cells: [true, true, true, true],
     });
     expect(rowDistance(ops)).toBe(1);
+  });
+});
+
+describe('renderRowDiff', () => {
+  it('marks changed cells, new rows and leaves paired rows as they are', () => {
+    const map = renderRowDiff(
+      [
+        { op: 'same', baselineRow: 0, currentRow: 0 },
+        { op: 'changed', baselineRow: 1, currentRow: 1, cells: [false, true, true, false] },
+        { op: 'added', currentRow: 2 },
+      ],
+      { cells: new Array(12).fill(0), rows: 3, cols: 4 },
+    );
+
+    const lines = map.trimEnd().split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toContain('X');
+    // Each line is prefixed with its row number so an elided map stays locatable.
+    expect(lines[2]).toMatch(/^\s*2\s+~ ~ ~ ~$/);
+  });
+
+  it('renders nothing for a diff with no operations', () => {
+    expect(renderRowDiff([], { cells: [], rows: 0, cols: 4 })).toBe('');
+  });
+});
+
+describe('renderRowDiff elision', () => {
+  const wideGrid = (rows: number): Grid => ({
+    cells: new Array<number>(rows * 4).fill(255),
+    rows,
+    cols: 4,
+  });
+
+  it('keeps untouched rows readable as structure rather than blanking them', () => {
+    const map = renderRowDiff(
+      [
+        { op: 'same', baselineRow: 0, currentRow: 0 },
+        { op: 'changed', baselineRow: 1, currentRow: 1, cells: [true, false, false, false] },
+      ],
+      wideGrid(2),
+    );
+
+    // Every cell of the grid is filled, so the unchanged row must show it.
+    expect(map).toContain('#');
+  });
+
+  it('elides long stretches of unchanged rows so a CI log stays readable', () => {
+    const ops: RowOp[] = Array.from({ length: 30 }, (_, row) =>
+      row === 15
+        ? { op: 'changed', baselineRow: row, currentRow: row, cells: [true, false, false, false] }
+        : { op: 'same', baselineRow: row, currentRow: row },
+    );
+
+    const map = renderRowDiff(ops, wideGrid(30));
+    const lines = map.trimEnd().split('\n');
+
+    expect(lines.length).toBeLessThan(12);
+    expect(map).toContain('unchanged');
+    expect(map).toContain('X');
+  });
+
+  it('does not elide when everything fits', () => {
+    const ops: RowOp[] = Array.from({ length: 4 }, (_, row) => ({
+      op: 'same',
+      baselineRow: row,
+      currentRow: row,
+    }));
+
+    expect(renderRowDiff(ops, wideGrid(4))).not.toContain('unchanged');
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
       name: 'TWD',
     },
     rollupOptions: {
-      external: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom', 'react-dom/client', 'fs', 'path', 'vite'],
+      external: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom', 'react-dom/client', 'fs', 'path', 'vite', /^node:/],
       output: [
         {
           format: 'es',


### PR DESCRIPTION
Two fixes on top of `matchLayout` (#337), found while running it end to end against a real landing page.

## 1. The snapshot plugin crashed the dev server

Any app adding `twdSnapshot()` to its Vite config died on startup:

```
TypeError: l.default.resolve is not a function
    at configureServer (twd-js/dist/vite-plugin.es.js:98:27)
```

`twdSnapshot.ts` imports `node:fs` and `node:path`, but `rollupOptions.external` only listed the unprefixed `'fs'` and `'path'`. Rolldown therefore tried to bundle the builtins and emitted broken interop. `removeMockServiceWorker.ts` was unaffected because it imports from `'path'` without the prefix, which is why this did not show up earlier.

Fixed by externalising `/^node:/`, so any builtin added later is covered without listing both spellings of every module by hand.

This is a release blocker: `matchLayout` is unusable without the plugin. `1.10.0` is not published yet, so it does not need a patch.

## 2. A CI failure did not say where the layout moved

The diff map was deliberately dropped as "a worse version of the picture that `<name>.failed.png` already shows". That holds in the sidebar, where the capture is one click away — but the capture is a **file**, and CI shows **logs**. A CI failure reported a row count and nothing else, which cannot distinguish an intended change from a regression without downloading an artifact.

The map is back, with three changes from the original spike version:

- **Hashes stay out.** Nobody can act on `00dd000020000018`. That part of the original call was right.
- **Only rows near a change are printed**, with two rows of context and the rest elided. A landing page is 36 rows tall, and dumping all of them is the noise the ASCII was accused of being. A diff prints hunks, not the whole file.
- **Unchanged rows keep their structure** (`#`/`.`) rather than being blanked, because that is what makes the marked rows locatable on the page.

A size-only change moves no row, so there the map is omitted entirely — the headline already carries the size delta.

```
Layout snapshot "landing" changed - 10 rows differ

  X = changed    ~ = new row    # = filled    . = empty
     ... 3 rows unchanged
    3  . . . . # # # # # # # . . . . .
    5  . . X X X X . X X X . . . . . .
     ... 2 rows unchanged
   19  X X X X X X X X X X X X X X X X
   23  ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
     ... 9 rows unchanged

  Reference:  __twd_snapshots__/landing.snap
  Capture:    __twd_snapshots__/landing.failed.png

  Accept:  npx twd-cli --update-snapshots
```

## Verification

- 497 tests pass, 0 lint errors. New tests were written failing first, for both the map and the elision.
- Verified end to end outside the repo: packed the build, installed it in a consumer app, and ran the tests through `twd-relay` against headless Chrome. The dev server now boots (it did not before) and the failure message carries the map.
- Behaviour is unchanged for the two cases the design was validated on: a reorder at constant height reports `10 rows differ` with the overlay on the moved elements, and a height change reports the size delta with a single band at the first divergence.