### PR TITLE
feat(sidebar): add an execution speed selector

### DIFF
--- a/docs/ai-remote-testing.md
+++ b/docs/ai-remote-testing.md
@@ -284,3 +284,9 @@ All messages are JSON over WebSocket. The `twd-relay run` CLI handles this proto
 ## Sidebar Integration
 
 When the relay triggers a test run, the TWD sidebar updates in real time. The browser client dispatches a `twd:state-change` event after each status update, and the sidebar listens for it to re-render with the latest results. You don't need to configure anything — if the relay is connected, the sidebar reflects relay-triggered runs automatically.
+
+A relay-triggered run executes at full speed, which makes it hard to see what an
+agent's new test actually did. Enable the sidebar speed selector with
+`twd({ pace: true })` and pick `Slow (300ms)`: the pace applies to relay-triggered
+runs too, so you can watch the flow the agent wrote before deciding to keep it.
+See [Recording Runs](/recording#watching-a-run-without-recording-it).

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -50,6 +50,7 @@ The `twd()` plugin accepts the following options:
 - **`serviceWorkerUrl`** (`string`, optional) - Custom path to the service worker file. Default: `'/mock-sw.js'`
 - **`theme`** (`Partial<TWDTheme>`, optional) - Custom theme configuration. See [Theming](/theming) for details.
 - **`search`** (`boolean`, optional) - Whether to show the search/filter input in the sidebar. Default: `false`
+- **`pace`** (`boolean`, optional) - Whether to show the execution speed selector in the sidebar, which slows a run down so you can watch it. Default: `false`
 
 **Examples:**
 
@@ -68,6 +69,9 @@ twd({ serviceWorker: false });
 
 // Enable test filtering in the sidebar
 twd({ search: true });
+
+// Enable the execution speed selector, to watch a run step by step
+twd({ pace: true });
 
 // All options together
 twd({

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,7 @@ export default defineConfig({
       open: true,
       position: 'left',
       search: true,                    // Enable search/filter in the sidebar (default: false)
+      pace: true,                      // Enable the execution speed selector (default: false)
       serviceWorker: true,             // Enable request mocking (default: true)
       serviceWorkerUrl: '/mock-sw.js', // Custom service worker path (default: '/mock-sw.js')
       // rootSelector: '#my-app',      // (Optional) Override the app root for screenDom queries
@@ -143,6 +144,7 @@ if (import.meta.env.DEV) {
     open: true,
     position: 'left',
     search: true,                    // Enable search/filter in the sidebar (default: false)
+    pace: true,                      // Enable the execution speed selector (default: false)
     serviceWorker: true,             // Enable request mocking (default: true)
     serviceWorkerUrl: '/mock-sw.js', // Custom service worker path (default: '/mock-sw.js')
     // rootSelector: '#my-app',      // (Optional) Override the app root for screenDom queries

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -140,6 +140,33 @@ npx twd-cli run --record --record-pace 0 --test "checkout flow"
 Values between 200 and 500 tend to read well. Pacing needs `twd-js` 1.9.0 or
 newer. On an older version the run still records, unpaced, and warns.
 
+## Watching a run without recording it
+
+The same pacing is available in the sidebar, without ffmpeg and without
+producing a file. Turn it on with the `pace` option:
+
+```ts
+// vite.config.ts
+twd({ pace: true });
+```
+
+That adds a speed selector to the sidebar header:
+
+| Option | Pace |
+|---|---|
+| `Off (full speed)` | `0` |
+| `Slow (300ms)` | `300` |
+| `Slower (600ms)` | `600` |
+
+The choice is remembered for the tab, so it survives the reloads you get while
+editing tests. It applies to every run in the page, including runs triggered
+over [twd-relay](/twd-relay), which is the point: when an agent writes a test and
+runs it for you, a paced run is one you can actually follow. Leave it on `Off`
+for normal development, where a run finishing in milliseconds is the feature.
+
+Like `record.pace`, this only spaces out commands. It does not change what the
+tests assert.
+
 ## A recorded run is not a CI run
 
 Recording changes the conditions the tests run under:

--- a/examples/twd-test-app/vite.config.ts
+++ b/examples/twd-test-app/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       requireEnv: process.env.CI ? true : false,
     }),
     twdRemote() as PluginOption,
-    twd({ testFilePattern: '/**/*.twd.test.{ts,tsx}', open: false, search: true }),
+    twd({ testFilePattern: '/**/*.twd.test.{ts,tsx}', open: false, search: true, pace: true }),
   ],
   resolve: {
     alias: {

--- a/src/bundled.tsx
+++ b/src/bundled.tsx
@@ -16,6 +16,7 @@ interface InitTWDOptions {
   serviceWorkerUrl?: string;
   theme?: Partial<TWDTheme>;
   search?: boolean;
+  pace?: boolean;
   rootSelector?: string;
 }
 
@@ -35,6 +36,8 @@ const createRoot = (el: HTMLElement) => ({
  * @param options.serviceWorker Whether to use the service worker
  * @param options.serviceWorkerUrl The URL of the service worker
  * @param options.theme Optional theme customization
+ * @param options.search Whether to show the search/filter input
+ * @param options.pace Whether to show the execution speed selector
  * @returns void
  * @example
  * initTWD(testModules, { open: true, position: 'left' });
@@ -46,6 +49,8 @@ const createRoot = (el: HTMLElement) => ({
  * initTWD(testModules, { open: true, position: 'left', theme: { primary: '#ff0000', background: '#ffffff' } });
  * @example
  * initTWD(testModules, { rootSelector: '#my-app' });
+ * @example
+ * initTWD(testModules, { pace: true });
  */
 export const initTWD = (files: TestModule, options?: InitTWDOptions) => {
   const {
@@ -55,6 +60,7 @@ export const initTWD = (files: TestModule, options?: InitTWDOptions) => {
     serviceWorkerUrl = '/mock-sw.js',
     theme,
     search,
+    pace,
     rootSelector,
   } = options || {};
   if (rootSelector) {
@@ -62,7 +68,12 @@ export const initTWD = (files: TestModule, options?: InitTWDOptions) => {
   }
   void initTests(
     files,
-    <TWDSidebar open={open} position={position} {...(search !== undefined && { search })} />,
+    <TWDSidebar
+      open={open}
+      position={position}
+      {...(search !== undefined && { search })}
+      {...(pace !== undefined && { pace })}
+    />,
     createRoot,
     theme,
   );

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,6 +6,11 @@ declare global {
     __testRunner?: any;
     __TWD_STATE__?: any;
     __twdSetPace?: (ms: unknown) => number;
+    /**
+     * Pacing state, shared by every copy of pace.ts the page has loaded.
+     * The sidebar and the test runner can come from different bundles.
+     */
+    __TWD_PACE__?: { paceMs: number; keyDelayMs: number; generation: number };
     __TWD_MOCK_STATE__?: any;
     __twdCollectMock?: (mock: {
       alias: string;

--- a/src/pace.ts
+++ b/src/pace.ts
@@ -3,9 +3,24 @@ import { wait } from './utils/wait';
 const MAX_PACE_MS = 5000;
 const MAX_KEY_DELAY_MS = 60;
 
-let paceMs = 0;
-let keyDelayMs = 0;
-let generation = 0;
+interface PaceState {
+  paceMs: number;
+  keyDelayMs: number;
+  generation: number;
+}
+
+const createState = (): PaceState => ({ paceMs: 0, keyDelayMs: 0, generation: 0 });
+
+/**
+ * Kept on the window rather than in module scope on purpose.
+ *
+ * twd-js ships this module inside more than one bundle: the sidebar runs the
+ * copy in bundled.es.js, while the user's tests import the copy in index.es.js.
+ * With module-local state the sidebar would set a pace the runner never reads.
+ * One object on the window keeps every copy in step, whichever one is asked.
+ */
+const state: PaceState =
+  typeof window !== 'undefined' ? (window.__TWD_PACE__ ??= createState()) : createState();
 
 /**
  * Sets the delay inserted after each paced command, in milliseconds.
@@ -21,10 +36,11 @@ let generation = 0;
  * @returns the pace actually applied
  */
 export const setPace = (ms: unknown): number => {
-  paceMs = typeof ms === 'number' && Number.isFinite(ms) && ms > 0 ? Math.min(ms, MAX_PACE_MS) : 0;
-  keyDelayMs = paceMs ? Math.min(MAX_KEY_DELAY_MS, Math.round(paceMs / 10)) : 0;
-  generation += 1;
-  return paceMs;
+  state.paceMs =
+    typeof ms === 'number' && Number.isFinite(ms) && ms > 0 ? Math.min(ms, MAX_PACE_MS) : 0;
+  state.keyDelayMs = state.paceMs ? Math.min(MAX_KEY_DELAY_MS, Math.round(state.paceMs / 10)) : 0;
+  state.generation += 1;
+  return state.paceMs;
 };
 
 /**
@@ -34,22 +50,22 @@ export const setPace = (ms: unknown): number => {
  * uniformly, so reusing the pace itself would put half a second between every
  * character.
  */
-export const getKeyDelay = (): number => keyDelayMs;
+export const getKeyDelay = (): number => state.keyDelayMs;
 
 /**
  * Bumped by every setPace call, so consumers holding derived state can tell it
  * is stale. Keying such a cache on the delay alone is not enough: setting the
  * same value twice must still invalidate.
  */
-export const getPaceGeneration = (): number => generation;
+export const getPaceGeneration = (): number => state.generation;
 
 /**
  * Returns undefined synchronously when pacing is off, so a normal run allocates
  * no promise and schedules no timer. Do not make this an async function.
  */
 export const pace = (): void | Promise<void> => {
-  if (!paceMs) return;
-  return wait(paceMs);
+  if (!state.paceMs) return;
+  return wait(state.paceMs);
 };
 
 if (typeof window !== 'undefined') {

--- a/src/plugin/twd.ts
+++ b/src/plugin/twd.ts
@@ -39,6 +39,10 @@ export interface TwdPluginOptions {
    */
   search?: boolean;
   /**
+   * Whether to show the execution speed selector in the sidebar.
+   */
+  pace?: boolean;
+  /**
    * CSS selector for the host element used to mount the sidebar.
    */
   rootSelector?: string;

--- a/src/tests/bundled/bundled.spec.ts
+++ b/src/tests/bundled/bundled.spec.ts
@@ -108,6 +108,15 @@ describe('initTWD', () => {
     expect(callArgs[1].props).toEqual({ open: true, position: 'left', search: true });
   });
 
+  it('should forward pace option to TWDSidebar', () => {
+    const files = {};
+    initTWD(files, { pace: true });
+
+    expect(initTests).toHaveBeenCalled();
+    const callArgs = (initTests as any).mock.calls[0];
+    expect(callArgs[1].props).toEqual({ open: true, position: 'left', pace: true });
+  });
+
   it('should call setRootSelector when rootSelector option is provided', () => {
     const files = {};
     initTWD(files, { rootSelector: '#my-app' });

--- a/src/tests/pace.spec.ts
+++ b/src/tests/pace.spec.ts
@@ -127,3 +127,40 @@ describe('public API surface', () => {
     expect('setPace' in twd).toBe(false);
   });
 });
+
+describe('state shared across module instances', () => {
+  afterEach(async () => {
+    vi.resetModules();
+    const fresh = await import('../pace');
+    fresh.setPace(0);
+  });
+
+  // twd-js ships pace.ts inside more than one bundle: the sidebar runs the copy
+  // in bundled.es.js while the user's tests import the copy in index.es.js.
+  // They share a window, so the pace one instance sets has to be the pace the
+  // other one applies, or the sidebar control silently does nothing.
+  it('applies a pace set on one instance to another instance', async () => {
+    vi.resetModules();
+    const sidebarCopy = await import('../pace');
+    vi.resetModules();
+    const runnerCopy = await import('../pace');
+    expect(sidebarCopy.setPace).not.toBe(runnerCopy.setPace);
+
+    sidebarCopy.setPace(300);
+
+    expect(runnerCopy.getKeyDelay()).toBe(30);
+    expect(runnerCopy.pace()).toBeInstanceOf(Promise);
+  });
+
+  it('invalidates the other instance derived state when the pace changes', async () => {
+    vi.resetModules();
+    const sidebarCopy = await import('../pace');
+    vi.resetModules();
+    const runnerCopy = await import('../pace');
+
+    const before = runnerCopy.getPaceGeneration();
+    sidebarCopy.setPace(600);
+
+    expect(runnerCopy.getPaceGeneration()).toBeGreaterThan(before);
+  });
+});

--- a/src/tests/plugin/twd.spec.ts
+++ b/src/tests/plugin/twd.spec.ts
@@ -56,6 +56,7 @@ describe('twd vite plugin', () => {
       const plugin = twd({
         position: 'right',
         search: true,
+        pace: true,
         theme: { primary: '#ff0000' },
         rootSelector: '#my-app',
       });
@@ -63,6 +64,7 @@ describe('twd vite plugin', () => {
       const code = load.call({}, '\0virtual:twd/init');
       expect(code).toContain(`"position":"right"`);
       expect(code).toContain(`"search":true`);
+      expect(code).toContain(`"pace":true`);
       expect(code).toContain(`"theme":{"primary":"#ff0000"}`);
       expect(code).toContain(`"rootSelector":"#my-app"`);
     });

--- a/src/tests/ui/twdSidebar.spec.tsx
+++ b/src/tests/ui/twdSidebar.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { expect as chaiExpect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor, act } from '@testing-library/react';
@@ -6,6 +6,7 @@ import * as twd from '../../runner';
 import { TWDSidebar } from '../../ui/TWDSidebar';
 import * as mockBridge from '../../commands/mockBridge';
 import * as componentMocks from '../../ui/componentMocks';
+import { setPace, getKeyDelay } from '../../pace';
 
 describe('TWDSidebar', () => {
   beforeEach(() => {
@@ -363,6 +364,69 @@ describe('TWDSidebar', () => {
       await waitFor(() => {
         expect(screen.getByText(/Test "Test 1" passed/)).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('pace control', () => {
+    afterEach(() => {
+      setPace(0);
+    });
+
+    it('should not render the speed select when pace prop is false', () => {
+      render(<TWDSidebar open={true} />);
+      expect(screen.queryByLabelText('Speed')).not.toBeInTheDocument();
+    });
+
+    it('should render the speed select when pace prop is true', () => {
+      render(<TWDSidebar open={true} pace={true} />);
+      expect(screen.getByLabelText('Speed')).toBeInTheDocument();
+    });
+
+    // getKeyDelay is the pace actually in force: pace.ts derives it as pace/10,
+    // so 30 proves setPace(300) reached the module the runner reads from.
+    it('should apply the selected speed to the runner', async () => {
+      const user = userEvent.setup();
+      render(<TWDSidebar open={true} pace={true} />);
+      await user.selectOptions(screen.getByLabelText('Speed'), '300');
+      expect(getKeyDelay()).toBe(30);
+    });
+
+    it('should persist the selected speed to sessionStorage', async () => {
+      const user = userEvent.setup();
+      render(<TWDSidebar open={true} pace={true} />);
+      await user.selectOptions(screen.getByLabelText('Speed'), '600');
+      expect(sessionStorage.getItem('twd-pace')).toBe('600');
+    });
+
+    it('should remove the sessionStorage entry when going back to full speed', async () => {
+      const user = userEvent.setup();
+      sessionStorage.setItem('twd-pace', '600');
+      render(<TWDSidebar open={true} pace={true} />);
+      await user.selectOptions(screen.getByLabelText('Speed'), '0');
+      expect(sessionStorage.getItem('twd-pace')).toBeNull();
+      expect(getKeyDelay()).toBe(0);
+    });
+
+    it('should restore the speed from sessionStorage on mount', () => {
+      sessionStorage.setItem('twd-pace', '600');
+      render(<TWDSidebar open={true} pace={true} />);
+      expect(screen.getByLabelText('Speed')).toHaveValue('600');
+      expect(getKeyDelay()).toBe(60);
+    });
+
+    it('should ignore a stored speed that is not one of the options', () => {
+      sessionStorage.setItem('twd-pace', '4500');
+      render(<TWDSidebar open={true} pace={true} />);
+      expect(screen.getByLabelText('Speed')).toHaveValue('0');
+      expect(getKeyDelay()).toBe(0);
+    });
+
+    it('should clear sessionStorage and stop pacing when pace prop is false', () => {
+      sessionStorage.setItem('twd-pace', '600');
+      setPace(600);
+      render(<TWDSidebar open={true} pace={false} />);
+      expect(sessionStorage.getItem('twd-pace')).toBeNull();
+      expect(getKeyDelay()).toBe(0);
     });
   });
 

--- a/src/ui/PaceSelect.tsx
+++ b/src/ui/PaceSelect.tsx
@@ -1,0 +1,39 @@
+/**
+ * The speeds offered in the sidebar.
+ *
+ * 300ms is what `twd-cli --record` paces a recorded run at, and the same value
+ * reads well when you are watching a run in your own tab. Anything faster is
+ * hard to follow, anything slower gets tedious past a handful of commands.
+ */
+export const PACE_OPTIONS = [
+  { value: 0, label: 'Off (full speed)' },
+  { value: 300, label: 'Slow (300ms)' },
+  { value: 600, label: 'Slower (600ms)' },
+] as const;
+
+interface PaceSelectProps {
+  value: number;
+  onChange: (ms: number) => void;
+}
+
+export const PaceSelect = ({ value, onChange }: PaceSelectProps) => {
+  return (
+    <div className="twd-pace-row">
+      <label className="twd-pace-label" htmlFor="twd-pace-select">
+        Speed
+      </label>
+      <select
+        id="twd-pace-select"
+        className="twd-pace-select"
+        value={value}
+        onChange={(e) => onChange(Number(e.currentTarget.value))}
+      >
+        {PACE_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/src/ui/TWDSidebar.tsx
+++ b/src/ui/TWDSidebar.tsx
@@ -16,6 +16,8 @@ import { TWD_VERSION } from '../constants/version';
 import { SearchInput } from './SearchInput';
 import { filterTree } from './utils/filterTree';
 import { buildTreeFromHandlers, type Node } from './utils/buildTreeFromHandlers';
+import { PaceSelect, PACE_OPTIONS } from './PaceSelect';
+import { setPace } from '../pace';
 
 interface TWDSidebarProps {
   /**
@@ -34,6 +36,10 @@ interface TWDSidebarProps {
    * Whether to show the search/filter input
    */
   search?: boolean;
+  /**
+   * Whether to show the execution speed selector
+   */
+  pace?: boolean;
 }
 
 const positionStyles = {
@@ -47,6 +53,20 @@ const getSearchQuery = (search?: boolean) => {
     return '';
   }
   return sessionStorage.getItem('twd-search-filter') || '';
+};
+
+const PACE_STORAGE_KEY = 'twd-pace';
+
+// Read back through the option list rather than trusting the stored number.
+// sessionStorage survives a reload that changed the options, and setPace clamps
+// silently, so an unknown value would leave the select and the runner disagreeing.
+const getStoredPace = (pace?: boolean) => {
+  if (!pace) {
+    sessionStorage.removeItem(PACE_STORAGE_KEY);
+    return 0;
+  }
+  const stored = Number(sessionStorage.getItem(PACE_STORAGE_KEY));
+  return PACE_OPTIONS.some((option) => option.value === stored) ? stored : 0;
 };
 
 const getOpenState = (open: boolean) => {
@@ -65,12 +85,20 @@ const collectTestIds = (nodes: Node[]): string[] => {
   return ids;
 };
 
-export const TWDSidebar = ({ open, position = 'left', search }: TWDSidebarProps) => {
+export const TWDSidebar = ({ open, position = 'left', search, pace }: TWDSidebarProps) => {
   const [refreshKey, setRefresh] = useState(0);
   const [isOpen, setIsOpen] = useState(getOpenState(open));
   useLayout({ isOpen, position });
   const [message, setMessage] = useState<string>('');
   const [searchQuery, setSearchQuery] = useState(getSearchQuery(search));
+  const [paceMs, setPaceMs] = useState(getStoredPace(pace));
+
+  // Pacing lives in module state so that every run picks it up, including the
+  // ones twd-relay triggers from outside the tab. The sidebar only has to keep
+  // that state in step with the selection.
+  useEffect(() => {
+    setPace(paceMs);
+  }, [paceMs]);
 
   useEffect(() => {
     const onStateChange = () => setRefresh((n) => n + 1);
@@ -134,6 +162,15 @@ export const TWDSidebar = ({ open, position = 'left', search }: TWDSidebarProps)
       sessionStorage.setItem('twd-search-filter', value);
     } else {
       sessionStorage.removeItem('twd-search-filter');
+    }
+  };
+
+  const handlePaceChange = (ms: number) => {
+    setPaceMs(ms);
+    if (ms) {
+      sessionStorage.setItem(PACE_STORAGE_KEY, ms.toString());
+    } else {
+      sessionStorage.removeItem(PACE_STORAGE_KEY);
     }
   };
 
@@ -261,6 +298,7 @@ export const TWDSidebar = ({ open, position = 'left', search }: TWDSidebarProps)
             </span>
           </div>
         </div>
+        {pace && <PaceSelect value={paceMs} onChange={handlePaceChange} />}
         <MockRulesButton />
         {search && <SearchInput value={searchQuery} onChange={handleSearchChange} />}
       </div>

--- a/src/ui/utils/styles.ts
+++ b/src/ui/utils/styles.ts
@@ -219,6 +219,37 @@ export const CSS_STYLES = `
 }
 
 /* ========================
+   Pace
+   ======================== */
+.twd-pace-row {
+  display: flex;
+  align-items: center;
+  gap: var(--twd-spacing-md);
+  margin-bottom: 10px;
+}
+.twd-pace-label {
+  font-size: var(--twd-font-size-sm);
+  color: var(--twd-text-secondary);
+  white-space: nowrap;
+}
+.twd-pace-select {
+  flex: 1;
+  min-width: 0;
+  padding: var(--twd-spacing-sm) var(--twd-spacing-md);
+  background: var(--twd-background);
+  color: var(--twd-text);
+  border: 1px solid var(--twd-border);
+  border-radius: var(--twd-border-radius);
+  font-size: var(--twd-font-size-sm);
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.twd-pace-select:focus-visible {
+  outline: 2px solid var(--twd-primary);
+  outline-offset: 2px;
+}
+
+/* ========================
    Loader
    ======================== */
 .twd-loader {


### PR DESCRIPTION
## Description

Tests run in milliseconds, which is the feature until you need to see what one of them actually does. That is the common case after an agent writes a test for you: it passes, and you still do not know what flow it exercised.

`twd-cli` already paces recorded runs so the video is watchable. This exposes the same mechanism in the sidebar, with no ffmpeg and no file produced. New opt-in option, off by default and threaded like `search`:

```ts
// vite.config.ts
twd({ pace: true });
```

That adds a `Speed` select to the sidebar header: `Off (full speed)`, `Slow (300ms)`, `Slower (600ms)`. 300ms is what `--record` defaults to and it reads as well live as it does on video. The choice is stored per tab in sessionStorage, so it survives the reloads that come with editing tests, and a stored value that is not one of the options is ignored rather than trusted.

Because pacing lives in shared state rather than in the sidebar, the selection also applies to runs triggered over `twd-relay`. That is the case worth having: an agent writes a test and runs it, and you watch it happen instead of trusting a green tick.

### Bundled a fix it depends on

The first commit is a real bug, found while verifying this feature by hand: the control appeared to do nothing.

`pace.ts` held `paceMs` in module scope, but the module ships inside more than one bundle. The sidebar runs the copy in `bundled.es.js`, while the user's tests import the copy in `index.es.js`. Setting a pace on one instance had no effect on the instance the runner reads.

`twd-cli` was only working by accident: it calls `window.__twdSetPace`, which every copy overwrites on load, and the copy the tests use happens to load last because `initTWD` imports the test files after the sidebar bundle. The state now lives on `window.__TWD_PACE__`, created once and reused by whichever copy loads next, so every copy reads and writes the same object. The public shape is unchanged, including the invariant that `pace()` returns `undefined` synchronously when pacing is off.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test addition or update

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass
- [x] New and existing unit tests pass locally
- [x] I have tested this change manually

### Test Details

`src/tests/pace.spec.ts`, for the fix: two `vi.resetModules()` imports of `pace.ts` stand in for the two shipped bundles. Setting a pace on one instance has to reach the other, and has to bump the generation the other one reads. Both fail on `main`, which is exactly the symptom seen in the browser.

`src/tests/ui/twdSidebar.spec.tsx`, for the control: hidden unless the option is set, applies the selected pace to the runner, persists to and restores from sessionStorage, drops the entry on the way back to full speed, ignores a stored value that is not an option, and clears the entry when the option is off. Each was watched failing first, and the stored-value validation was mutated away to confirm its test catches the regression.

Option pass-through is covered in `src/tests/bundled/bundled.spec.ts` and `src/tests/plugin/twd.spec.ts`.

508 tests pass across 66 files. Lint and prettier clean, `npm run build` succeeds.

Manually verified in `examples/twd-test-app`: at `Slow (300ms)` a form fills character by character, at `Off` the run is instant.

## Documentation

- [x] I have updated the documentation accordingly
- [x] I have added/updated code comments where necessary
- [x] The changes are reflected in the relevant documentation files

`getting-started.md` (both option lists), `frameworks.md` (option reference and example), a new "Watching a run without recording it" section in `recording.md`, and a pointer from the Sidebar Integration section of `ai-remote-testing.md` where the agent workflow is described.
