### PR TITLE
docs: make mocking examples follow our own selector guidance

### DIFF
--- a/docs/api-mocking.md
+++ b/docs/api-mocking.md
@@ -92,10 +92,18 @@ You only need to register request mocking once (via the plugin or `initTWD`/`ini
 
 ## Basic Mocking
 
+::: tip Selecting elements in these examples
+The examples below query with Testing Library's async `findBy*` methods —
+`findByRole`, `findByLabelText`, `findByText` — rather than CSS or test-id
+selectors. That is the order [Writing Tests](/writing-tests#element-selection)
+recommends: `findBy*` waits for the element to appear, which matters when you
+are asserting on UI that updates after a mocked response resolves.
+:::
+
 ### Simple GET Request
 
 ```ts
-import { twd, userEvent } from "twd-js";
+import { twd, screenDom, userEvent } from "twd-js";
 import { describe, it } from "twd-js/runner";
 
 describe("User Profile", () => {
@@ -114,15 +122,15 @@ describe("User Profile", () => {
     await twd.visit("/profile");
 
     // Trigger the request
-    const loadButton = await twd.get("button[data-testid='load-profile']");
-    await userEvent.click(loadButton.el);
+    const loadButton = await screenDom.findByRole("button", { name: "Load profile" });
+    await userEvent.click(loadButton);
 
     // Wait for the mock to be called
     await twd.waitForRequest("getUser");
 
     // Verify the UI updated
-    const userName = await twd.get("[data-testid='user-name']");
-    userName.should("have.text", "John Doe");
+    const userName = await screenDom.findByRole("heading", { name: "John Doe" });
+    twd.should(userName, "be.visible");
   });
 });
 ```
@@ -148,11 +156,11 @@ it("should create new user", async () => {
   const user = userEvent.setup();
   
   // Fill form
-  await user.type(await twd.get("#name"), "Jane Smith");
-  await user.type(await twd.get("#email"), "jane@example.com");
+  await user.type(await screenDom.findByLabelText("Name"), "Jane Smith");
+  await user.type(await screenDom.findByLabelText("Email"), "jane@example.com");
   
   // Submit form
-  await user.click(await twd.get("button[type='submit']"));
+  await user.click(await screenDom.findByRole("button", { name: "Submit" }));
 
   // Wait for request and verify
   const rule = await twd.waitForRequest("createUser");
@@ -185,8 +193,8 @@ it("should handle dynamic user IDs", async () => {
   await twd.visit("/users/123");
   
   // Trigger request and verify
-  const loadButton = await twd.get("button[data-testid='load-user']");
-  await userEvent.click(loadButton.el);
+  const loadButton = await screenDom.findByRole("button", { name: "Load user" });
+  await userEvent.click(loadButton);
   
   await twd.waitForRequest("getUserById");
 });
@@ -282,14 +290,14 @@ it("should handle API errors", async () => {
 
   await twd.visit("/user/999");
 
-  const loadButton = await twd.get("button[data-testid='load-user']");
-  await userEvent.click(loadButton.el);
+  const loadButton = await screenDom.findByRole("button", { name: "Load user" });
+  await userEvent.click(loadButton);
 
   await twd.waitForRequest("getUserError");
 
   // Verify error handling
-  const errorMessage = await twd.get(".error-message");
-  errorMessage.should("contain.text", "User not found");
+  const errorMessage = await screenDom.findByRole("alert");
+  twd.should(errorMessage, "contain.text", "User not found");
 });
 ```
 
@@ -315,8 +323,8 @@ it("should handle multiple API calls", async () => {
 
   await twd.visit("/user/123");
 
-  const loadButton = await twd.get("button[data-testid='load-all']");
-  await userEvent.click(loadButton.el);
+  const loadButton = await screenDom.findByRole("button", { name: "Load all" });
+  await userEvent.click(loadButton);
 
   // Wait for both requests
   const rules = await twd.waitForRequests(["getUser", "getUserPosts"]);
@@ -324,10 +332,10 @@ it("should handle multiple API calls", async () => {
   expect(rules).to.have.length(2);
 
   // Verify UI shows both user and posts
-  const userName = await twd.get("[data-testid='user-name']");
-  userName.should("have.text", "John Doe");
+  const userName = await screenDom.findByRole("heading", { name: "John Doe" });
+  twd.should(userName, "be.visible");
 
-  const posts = await twd.getAll(".post-item");
+  const posts = await screenDom.findAllByRole("listitem");
   expect(posts).to.have.length(2);
 });
 ```
@@ -351,16 +359,16 @@ it("should show loading state while waiting for API", async () => {
   await twd.visit("/profile");
 
   // Loading indicator should be visible while waiting
-  const spinner = await twd.get("[data-testid='loading-spinner']");
-  spinner.should("be.visible");
+  const spinner = await screenDom.findByRole("status");
+  twd.should(spinner, "be.visible");
 
   // Wait for the request to complete
   await twd.waitForRequest("getUser");
 
   // After the response arrives, loading should be gone
-  await twd.notExists("[data-testid='loading-spinner']");
-  const userName = await twd.get("[data-testid='user-name']");
-  userName.should("have.text", "John Doe");
+  await twd.notExists("[role='status']");
+  const userName = await screenDom.findByRole("heading", { name: "John Doe" });
+  twd.should(userName, "be.visible");
 });
 ```
 
@@ -386,8 +394,8 @@ it("should handle timeout-like errors", async () => {
   await twd.waitForRequest("slowError");
   await twd.wait(3100); // Wait for the delayed response to arrive
 
-  const errorMessage = await twd.get(".error-message");
-  errorMessage.should("contain.text", "Gateway Timeout");
+  const errorMessage = await screenDom.findByRole("alert");
+  twd.should(errorMessage, "contain.text", "Gateway Timeout");
 });
 ```
 
@@ -410,8 +418,8 @@ it("should call the API exactly twice", async () => {
   await twd.visit("/profile");
 
   // Trigger two requests
-  const refreshButton = await twd.get("button[data-testid='refresh']");
-  await userEvent.click(refreshButton.el);
+  const refreshButton = await screenDom.findByRole("button", { name: "Refresh" });
+  await userEvent.click(refreshButton);
   await twd.waitForRequest("getUser");
 
   // Re-register to reset executed flag for second wait
@@ -421,7 +429,7 @@ it("should call the API exactly twice", async () => {
     response: { id: 1, name: "John" },
   });
 
-  await userEvent.click(refreshButton.el);
+  await userEvent.click(refreshButton);
   await twd.waitForRequest("getUser");
 
   // Assert the count
@@ -490,13 +498,13 @@ it("should handle changing API responses", async () => {
 
   await twd.visit("/dashboard");
 
-  const refreshButton = await twd.get("button[data-testid='refresh']");
-  await userEvent.click(refreshButton.el);
+  const refreshButton = await screenDom.findByRole("button", { name: "Refresh" });
+  await userEvent.click(refreshButton);
 
   await twd.waitForRequest("getStatus");
 
-  let statusText = await twd.get("[data-testid='status']");
-  statusText.should("have.text", "loading");
+  let statusText = await screenDom.findByRole("status");
+  twd.should(statusText, "have.text", "loading");
 
   // Update the mock
   await twd.mockRequest("getStatus", {
@@ -506,11 +514,11 @@ it("should handle changing API responses", async () => {
   });
 
   // Trigger another request
-  await userEvent.click(refreshButton.el);
+  await userEvent.click(refreshButton);
   await twd.waitForRequest("getStatus");
 
-  statusText = await twd.get("[data-testid='status']");
-  statusText.should("have.text", "completed");
+  statusText = await screenDom.findByRole("status");
+  twd.should(statusText, "have.text", "completed");
 });
 ```
 
@@ -555,9 +563,9 @@ it("should handle authentication states", async () => {
 
   // Login and verify
   const user = userEvent.setup();
-  await user.type(await twd.get("#username"), "john");
-  await user.type(await twd.get("#password"), "password");
-  await user.click(await twd.get("button[type='submit']"));
+  await user.type(await screenDom.findByLabelText("Username"), "john");
+  await user.type(await screenDom.findByLabelText("Password"), "password");
+  await user.click(await screenDom.findByRole("button", { name: "Submit" }));
 
   await twd.waitForRequest("login");
   
@@ -565,8 +573,8 @@ it("should handle authentication states", async () => {
   await twd.visit("/profile");
   await twd.waitForRequest("getProfile");
   
-  const profileName = await twd.get("[data-testid='profile-name']");
-  profileName.should("have.text", "John Doe");
+  const profileName = await screenDom.findByRole("heading", { name: "John Doe" });
+  twd.should(profileName, "be.visible");
 });
 ```
 
@@ -587,12 +595,12 @@ it("should send correct form data", async () => {
   const user = userEvent.setup();
   
   // Fill form
-  await user.type(await twd.get("#email"), "test@example.com");
-  await user.type(await twd.get("#message"), "Hello world");
-  await user.click(await twd.get("#newsletter"));
+  await user.type(await screenDom.findByLabelText("Email"), "test@example.com");
+  await user.type(await screenDom.findByLabelText("Message"), "Hello world");
+  await user.click(await screenDom.findByRole("checkbox", { name: "Subscribe to newsletter" }));
 
   // Submit
-  await user.click(await twd.get("button[type='submit']"));
+  await user.click(await screenDom.findByRole("button", { name: "Submit" }));
 
   // Verify request data
   const rule = await twd.waitForRequest("submitForm");
@@ -617,8 +625,8 @@ it("should send the correct request body", async () => {
 
   await twd.visit("/protected");
 
-  const loadButton = await twd.get("button[data-testid='load-protected']");
-  await userEvent.click(loadButton.el);
+  const loadButton = await screenDom.findByRole("button", { name: "Load protected" });
+  await userEvent.click(loadButton);
 
   const rule = await twd.waitForRequest("authenticatedRequest");
 
@@ -706,19 +714,19 @@ it("should display error message on API failure", async () => {
 
   await twd.visit("/data-page");
 
-  const loadButton = await twd.get("button[data-testid='load-data']");
-  await userEvent.click(loadButton.el);
+  const loadButton = await screenDom.findByRole("button", { name: "Load data" });
+  await userEvent.click(loadButton);
 
   await twd.waitForRequest("failedRequest");
 
   // Verify error display
-  const errorMessage = await twd.get(".error-message");
-  errorMessage.should("be.visible");
-  errorMessage.should("contain.text", "Something went wrong");
+  const errorMessage = await screenDom.findByRole("alert");
+  twd.should(errorMessage, "be.visible");
+  twd.should(errorMessage, "contain.text", "Something went wrong");
 
   // Verify retry button appears
-  const retryButton = await twd.get("button[data-testid='retry']");
-  retryButton.should("be.visible");
+  const retryButton = await screenDom.findByRole("button", { name: "Retry" });
+  twd.should(retryButton, "be.visible");
 });
 ```
 
@@ -764,17 +772,17 @@ it("should handle paginated results", async () => {
   // Load first page
   await twd.waitForRequest("getPage1");
   
-  let users = await twd.getAll(".user-item");
+  let users = await screenDom.findAllByRole("listitem");
   expect(users).to.have.length(2);
 
   // Load next page
-  const nextButton = await twd.get("button[data-testid='next-page']");
-  await userEvent.click(nextButton.el);
+  const nextButton = await screenDom.findByRole("button", { name: "Next page" });
+  await userEvent.click(nextButton);
 
   await twd.waitForRequest("getPage2");
 
   // Should now have 4 users total
-  users = await twd.getAll(".user-item");
+  users = await screenDom.findAllByRole("listitem");
   expect(users).to.have.length(1);
 });
 ```
@@ -831,14 +839,14 @@ await twd.mockRequest("saveUser", {
 await twd.visit("/users/new");
 
 const user = userEvent.setup();
-await user.type(await twd.get("#name"), "John Doe");
-await user.type(await twd.get("#email"), "john.doe@example.com");
-await user.click(await twd.get("button[type='submit']"));
+await user.type(await screenDom.findByLabelText("Name"), "John Doe");
+await user.type(await screenDom.findByLabelText("Email"), "john.doe@example.com");
+await user.click(await screenDom.findByRole("button", { name: "Submit" }));
 
 await twd.waitForRequest("saveUser");
 
-const userName = await twd.get("[data-testid='user-name']");
-userName.should("have.text", "John Doe");
+const userName = await screenDom.findByRole("heading", { name: "John Doe" });
+twd.should(userName, "be.visible");
 ```
 
 ```ts
@@ -846,9 +854,9 @@ userName.should("have.text", "John Doe");
 await twd.visit("/users/new");
 
 const user = userEvent.setup();
-await user.type(await twd.get("#name"), "John Doe");
-await user.type(await twd.get("#email"), "john.doe@example.com");
-await user.click(await twd.get("button[type='submit']"));
+await user.type(await screenDom.findByLabelText("Name"), "John Doe");
+await user.type(await screenDom.findByLabelText("Email"), "john.doe@example.com");
+await user.click(await screenDom.findByRole("button", { name: "Submit" }));
 // Bad ❌ - mock after request event is fired
 twd.mockRequest("saveUser", {
   method: "POST",

--- a/docs/component-mocking.md
+++ b/docs/component-mocking.md
@@ -63,7 +63,7 @@ The `name` prop must be unique and match the name used in your test when calling
 Use `twd.mockComponent()` to replace the component with a mock implementation:
 
 ```ts
-import { twd, userEvent } from "twd-js";
+import { twd, screenDom, userEvent } from "twd-js";
 import { describe, it, beforeEach } from "twd-js/runner";
 
 interface ButtonProps {
@@ -89,15 +89,15 @@ describe("Component Mocking", () => {
     ));
 
     await twd.visit("/counter");
-    let button = await twd.get("button");
-    button.should("have.text", "Click me 0");
+    let button = await screenDom.findByRole("button");
+    twd.should(button, "have.text", "Click me 0");
     
-    await userEvent.click(button.el);
-    button = await twd.get("button");
-    button.should("have.text", "Click me 2");
+    await userEvent.click(button);
+    button = await screenDom.findByRole("button");
+    twd.should(button, "have.text", "Click me 2");
     
-    const countText = await twd.get("p");
-    countText.should("have.text", "Count: 2");
+    const countText = await screenDom.findByText(/^Count:/);
+    twd.should(countText, "have.text", "Count: 2");
   });
 });
 ```
@@ -117,12 +117,12 @@ it("should use mocked component behavior", async () => {
 
   await twd.visit("/counter");
   
-  const button = await twd.get("button");
-  await userEvent.click(button.el);
+  const button = await screenDom.findByRole("button");
+  await userEvent.click(button);
   
   // Verify the mock behavior
-  const countText = await twd.get("p");
-  countText.should("have.text", "Count: 10");
+  const countText = await screenDom.findByText(/^Count:/);
+  twd.should(countText, "have.text", "Count: 10");
 });
 ```
 
@@ -135,15 +135,15 @@ it("should use original component when not mocked", async () => {
   // Don't call twd.mockComponent() - component uses original behavior
   await twd.visit("/counter");
   
-  let button = await twd.get("button");
-  button.should("have.text", "Click me 0");
+  let button = await screenDom.findByRole("button");
+  twd.should(button, "have.text", "Click me 0");
   
-  await userEvent.click(button.el);
-  button = await twd.get("button");
-  button.should("have.text", "Click me 1");
+  await userEvent.click(button);
+  button = await screenDom.findByRole("button");
+  twd.should(button, "have.text", "Click me 1");
   
-  const countText = await twd.get("p");
-  countText.should("have.text", "Count: 1");
+  const countText = await screenDom.findByText(/^Count:/);
+  twd.should(countText, "have.text", "Count: 1");
 });
 ```
 
@@ -158,14 +158,14 @@ it("should handle conditional mocking", async () => {
   twd.mockComponent("UserCard", ({ user, onEdit }: UserCardProps) => {
     if (user.role === "admin") {
       return (
-        <div data-testid="admin-card">
+        <div>
           <h3>{user.name} (Admin)</h3>
           <button onClick={() => onEdit(user.id)}>Edit</button>
         </div>
       );
     }
     return (
-      <div data-testid="user-card">
+      <div>
         <h3>{user.name}</h3>
       </div>
     );
@@ -173,8 +173,8 @@ it("should handle conditional mocking", async () => {
 
   await twd.visit("/users/123");
   
-  const adminCard = await twd.get("[data-testid='admin-card']");
-  adminCard.should("be.visible");
+  const adminCard = await screenDom.findByRole("heading", { name: /\(Admin\)/ });
+  twd.should(adminCard, "be.visible");
 });
 ```
 
@@ -185,7 +185,7 @@ You can completely change what the component renders:
 ```ts
 it("should render completely different content", async () => {
   twd.mockComponent("ComplexChart", () => (
-    <div data-testid="mock-chart">
+    <div>
       <p>Chart data would be displayed here</p>
       <button>Refresh Chart</button>
     </div>
@@ -193,9 +193,12 @@ it("should render completely different content", async () => {
 
   await twd.visit("/dashboard");
   
-  const mockChart = await twd.get("[data-testid='mock-chart']");
-  mockChart.should("be.visible");
-  mockChart.should("contain.text", "Chart data would be displayed here");
+  const mockChart = await screenDom.findByText("Chart data would be displayed here");
+  twd.should(mockChart, "be.visible");
+
+  // The mock replaced the real chart, so its button is present too.
+  const refresh = await screenDom.findByRole("button", { name: "Refresh Chart" });
+  twd.should(refresh, "be.visible");
 });
 ```
 
@@ -208,7 +211,7 @@ it("should handle component errors", async () => {
   twd.mockComponent("DataFetcher", ({ onError }: DataFetcherProps) => {
     // Simulate an error state
     return (
-      <div data-testid="error-state">
+      <div role="alert">
         <p>Failed to load data</p>
         <button onClick={() => onError(new Error("Network error"))}>
           Retry
@@ -219,9 +222,9 @@ it("should handle component errors", async () => {
 
   await twd.visit("/data-page");
   
-  const errorState = await twd.get("[data-testid='error-state']");
-  errorState.should("be.visible");
-  errorState.should("contain.text", "Failed to load data");
+  const errorState = await screenDom.findByRole("alert");
+  twd.should(errorState, "be.visible");
+  twd.should(errorState, "contain.text", "Failed to load data");
 });
 ```
 
@@ -233,21 +236,21 @@ You can mock multiple components in the same test:
 it("should mock multiple components", async () => {
   // Mock first component
   twd.mockComponent("Header", () => (
-    <header data-testid="mock-header">Mock Header</header>
+    <header>Mock Header</header>
   ));
 
   // Mock second component
   twd.mockComponent("Footer", () => (
-    <footer data-testid="mock-footer">Mock Footer</footer>
+    <footer>Mock Footer</footer>
   ));
 
   await twd.visit("/page");
   
-  const header = await twd.get("[data-testid='mock-header']");
-  const footer = await twd.get("[data-testid='mock-footer']");
+  const header = await screenDom.findByRole("banner");
+  const footer = await screenDom.findByRole("contentinfo");
   
-  header.should("be.visible");
-  footer.should("be.visible");
+  twd.should(header, "be.visible");
+  twd.should(footer, "be.visible");
 });
 ```
 


### PR DESCRIPTION
## Description

Our docs already give the right advice, then demonstrate the opposite.

`writing-tests.md` says to prefer Testing Library's async `findBy*` queries **"ahead of `getBy*`/`queryBy*` and ahead of TWD's native `twd.get()`"**, and `testing-library.md` has a *Prefer Role-Based Queries* section. But the two mocking pages used **30 `data-testid` selectors** via `twd.get()`:

```ts
const loadButton = await twd.get("button[data-testid='load-profile']");
const userName = await twd.get("[data-testid='user-name']");
await twd.notExists("[data-testid='loading-spinner']");
```

These are the pages people copy from while learning to mock, so in practice they teach the pattern our own guidance warns against.

Why it matters beyond consistency: a test id proves a `div` exists. It says nothing about whether the feature is usable, and a suite built on test ids passes just as happily on markup no screen reader can interpret. Querying the way assistive technology does turns an a11y regression into a failing test.

**The change** — both mocking pages rewritten to accessible async queries:

```ts
const loadButton = await screenDom.findByRole("button", { name: "Load profile" });
const userName = await screenDom.findByRole("heading", { name: "John Doe" });
await user.type(await screenDom.findByLabelText("Email"), "jane@example.com");
const errorMessage = await screenDom.findByRole("alert");
```

`component-mocking.md` got a bonus: its mock components are defined inline, so the markup improved alongside the queries. The error-state mock is now `role="alert"` (what an error region should be anyway), and `<header>`/`<footer>` are queried as `banner`/`contentinfo` instead of carrying redundant test ids on top of elements that already have those roles implicitly.

Also removed a few tautologies — after `findByRole("heading", { name: "John Doe" })`, asserting `have.text` is `"John Doe"` only re-checks what the query already proved.

**Deliberately out of scope:**

- **The tutorial pages.** They are written against the cloned `twd-docs-tutorial` app, whose components are built on `data-testid` and mostly lack accessible names. Rewriting those queries would produce examples that don't work against the repo readers actually clone — that needs the tutorial app updated first, as its own change.
- **The API reference sections** in `testing-library.md` and `writing-tests.md` documenting `getBy*` and `twd.get`. Those correctly describe what exists.

Fixes # (no issue — spotted while adopting these conventions in a downstream project)

## Type of Change

- [x] Documentation update

## Testing

- [x] All existing tests pass
- [x] I have tested this change manually

**On the "no tests, no review" rule:** this changes only markdown prose and example snippets — no `src/` files, so there is no behaviour to cover with a test. Flagging it explicitly rather than quietly skipping the section. Happy to add something if you'd rather these examples be executable.

### Test Details

No tests added — documentation-only change. Verification was:

- `npm run docs:build` passes, including VitePress dead-link checking. A new cross-reference from `api-mocking.md` to `/writing-tests#element-selection` resolves against the real heading.
- Manually reviewed the full diff for mangled replacements: no leftover `.el` unwraps, no stray `twd.get(`/`data-testid` in either file, and `screenDom` added to the import line of every example that now uses it.

## Documentation

- [x] I have updated the documentation accordingly
- [x] The changes are reflected in the relevant documentation files

This *is* the documentation change. No public API is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)